### PR TITLE
Expose setting the offset at which to start matching a regexp

### DIFF
--- a/async/rxx.C
+++ b/async/rxx.C
@@ -151,7 +151,7 @@ rxx::init (const char *pat, const char *opt)
 }
 
 bool
-rxx::_exec (const char *p, size_t len, int options)
+rxx::_exec (const char *p, size_t len, int options, int offset)
 {
   bool ok = true;
   subj = NULL;
@@ -159,7 +159,7 @@ rxx::_exec (const char *p, size_t len, int options)
 		
   if (!ovector)
     ovector = New int[ovecsize];
-  nsubpat = pcre_exec (re, extra, p, len, 0,
+  nsubpat = pcre_exec (re, extra, p, len, offset,
 		       options, ovector, ovecsize);
   if (nsubpat <= 0 && nsubpat != PCRE_ERROR_NOMATCH)  {
     _errcode = nsubpat;

--- a/async/rxx.h
+++ b/async/rxx.h
@@ -73,7 +73,7 @@ protected:
 
 
 public:
-  bool _exec (const char *p, size_t len, int options);
+  bool _exec (const char *p, size_t len, int options = 0, int offset = 0);
   bool exec (str s, int options);
 
   class matchresult {


### PR DESCRIPTION
Needed to support finding multiple matches without breaking patterns with anchors like `^` or `$`.