### PR TITLE
sfs_assert: do not re-export the whole config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ tools/tinetd/Makefile.in
 /autom4te*.cache
 /config.cache
 /config.guess
+/config.h
+/config.h.in
 /config.log
 /config.status
 /config.sub
@@ -290,6 +292,3 @@ tools/tinetd/Makefile.in
 /tutorial/ex10.C
 /tutorial/ex3b.C
 /tutorial/ex12.C
-
-/async/sfs_config.h
-/async/sfs_config.h.in

--- a/acsfs.m4
+++ b/acsfs.m4
@@ -2017,10 +2017,10 @@ if test "${with_tag+set}" = "set" -a "$with_tag" != "no"; then
 	sfstag=$with_tag
 fi
 install_to_system_bin=0
-sfsdebug="no"
+sfsdebug=0
 case $with_mode in
 	"debug" )
-		sfsdebug="yes"
+		sfsdebug=1
 		DEBUG=-g
 		CXXDEBUG=-g
 		sfstag=$with_mode
@@ -2048,7 +2048,7 @@ case $with_mode in
 		;;
 
 	"shdbg"  )
-		sfsdebug="yes"
+		sfsdebug=1
 		sfstag=$with_mode
 		enable_shared=yes
 		DEBUG=-g
@@ -2063,7 +2063,7 @@ case $with_mode in
 		;;
 
 	"pydbg" )
-		sfsdebug="yes"
+		sfsdebug=1
 		sfstag=$with_mode
 		DEBUG=-g
 		CXXDEBUG=-g
@@ -2106,13 +2106,14 @@ fi
 
 AC_SUBST(sfstagdir)
 AC_SUBST(sfstag)
+AC_SUBST(sfsdebug)
 
 if test "${enable_shared}" = "yes"; then
 	AC_DEFINE(SFS_COMPILE_SHARED, 1,
 	     Define if SFS libs are compiled with shared libs)
 fi
 
-if test "x${sfsdebug}" = "xyes"; then
+if test "x${sfsdebug}" = "x1"; then
 	AC_DEFINE([SFS_DEBUG], 1,
 	     [Define if SFS libs are compiled in debug mode])
 fi

--- a/async/Makefile.am
+++ b/async/Makefile.am
@@ -29,7 +29,7 @@ parseopt.h qhash.h refcnt.h rxx.h serial.h stllike.h str.h	\
 suio++.h sysconf.h union.h vatmpl.h vec.h rwfd.h litetime.h       	\
 corebench.h qtailq.h sfs_select.h rclist.h dynenum.h         \
 rctailq.h rctree.h sfs_bundle.h alog2.h sfs_profiler.h wide_str.h 	\
-sfs_const.h weak_template.h sfs_config.h sfs_assert.h
+sfs_const.h sfs_assert.h weak_template.h
 
 #
 # begin sfslite changes

--- a/async/sfs_assert.h.in
+++ b/async/sfs_assert.h.in
@@ -1,10 +1,14 @@
 // -*-c++-*-
 #pragma once
-#include "sfs_config.h"
 #include <cassert>
 
-#ifdef SFS_DEBUG
+#define _SFS_DEBUG @sfsdebug@
+
+#if _SFS_DEBUG == 1
+#define SFS_DEBUG 1
 #define DASSERT(_X) assert(_X)
 #else
 #define DASSERT(_X)
 #endif
+
+#undef _SFS_DEGUG

--- a/async/sysconf.h
+++ b/async/sysconf.h
@@ -39,7 +39,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #ifdef HAVE_CONFIG_H
-#include "sfs_config.h"
+#include <config.h>
 #endif /* HAVE_CONFIG_H */
 
 #include "autoconf.h"

--- a/configure.in
+++ b/configure.in
@@ -5,7 +5,7 @@ dnl
 
 AC_INIT(acinclude.m4)
 AM_INIT_AUTOMAKE(sfslite,1.2.9.15)
-AM_CONFIG_HEADER(async/sfs_config.h)
+AM_CONFIG_HEADER(config.h)
 
 dnl
 dnl Autoconf now recommending this...
@@ -510,7 +510,7 @@ AC_OUTPUT(Makefile async/Makefile libsafeptr/Makefile rpcc/Makefile
 	arpcgen/Makefile 
         libsfs/Makefile tests/Makefile tutorial/Makefile
 	tools/Makefile tools/rtftp/Makefile tools/tinetd/Makefile
-	tools/logger/Makefile tools/ncpp/Makefile )
+	tools/logger/Makefile tools/ncpp/Makefile async/sfs_assert.h)
 
 dnl
 dnl end SFSlite changes

--- a/crypt/mpz_xor.C
+++ b/crypt/mpz_xor.C
@@ -23,7 +23,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include "sfs_config.h"
+#include <config.h>
 #endif /* HAVE_CONFIG_H */
 
 #ifndef HAVE_MPZ_XOR

--- a/sfsmisc/mallock.C
+++ b/sfsmisc/mallock.C
@@ -1,6 +1,6 @@
 /* $Id$ */
 
-#include "sfs_config.h"
+#include <config.h>
 #include "init.h"
 
 #if defined (HAVE_MLOCKALL)


### PR DESCRIPTION
This is a less intrusive and safer way to define DASSERT
