### PR TITLE
Reduce number of exported symbols

### DIFF
--- a/arpc/rpctypes.h
+++ b/arpc/rpctypes.h
@@ -78,18 +78,19 @@ template<class T> class rpc_ptr {
   T *p;
 
 public:
-  rpc_ptr () { p = NULL; }
-  rpc_ptr (const rpc_ptr &rp) { p = rp ? New T (*rp) : NULL; }
-  ~rpc_ptr () { delete p; }
+  SFS_INLINE_VISIBILITY rpc_ptr () { p = NULL; }
+  SFS_INLINE_VISIBILITY rpc_ptr (const rpc_ptr &rp) { p = rp ? New T (*rp) :
+      NULL; }
+  SFS_INLINE_VISIBILITY ~rpc_ptr () { delete p; }
 
-  void clear () { delete p; p = NULL; }
-  rpc_ptr &alloc () { if (!p) p = New T; return *this; }
+  SFS_INLINE_VISIBILITY void clear () { delete p; p = NULL; }
+  SFS_INLINE_VISIBILITY rpc_ptr &alloc () { if (!p) p = New T; return *this; }
   rpc_ptr &assign (T *tp) { clear (); p = tp; return *this; }
   T *release () { T *r = p; p = NULL; return r; }
 
-  operator T *() const { return p; }
-  T *operator-> () const { return p; }
-  T &operator* () const { return *p; }
+  SFS_INLINE_VISIBILITY operator T *() const { return p; }
+  SFS_INLINE_VISIBILITY T *operator-> () const { return p; }
+  SFS_INLINE_VISIBILITY T &operator* () const { return *p; }
 
   rpc_ptr &operator= (const rpc_ptr &rp) {
     if (!rp.p)
@@ -126,8 +127,8 @@ public:
 protected:
   bool nofree;
 
-  void init () { nofree = false; super::init (); }
-  void del () { if (!nofree) super::del (); }
+  SFS_INLINE_VISIBILITY  void init () { nofree = false; super::init (); }
+  SFS_INLINE_VISIBILITY  void del () { if (!nofree) super::del (); }
 
   void copy (const elm_t *p, size_t n) {
     clear ();
@@ -152,29 +153,36 @@ protected:
       init ();
     super::operator= (v);
   }
-  void ensure (size_t m) { assert (!nofree); assert (size () + m <= maxsize); }
+  SFS_INLINE_VISIBILITY  void ensure (size_t m) {
+    assert (!nofree);
+    assert (size () + m <= maxsize);
+  }
 
 public:
-  rpc_vec () { init (); }
-  rpc_vec (const rpc_vec &v) { init (); copy (v); }
+  SFS_INLINE_VISIBILITY  rpc_vec () { init (); }
+  SFS_INLINE_VISIBILITY  rpc_vec (const rpc_vec &v) { init (); copy (v); }
 
   #ifdef __GXX_EXPERIMENTAL_CXX0X__
-  explicit rpc_vec(std::initializer_list<T> l) : rpc_vec() {
+  SFS_INLINE_VISIBILITY  explicit rpc_vec(std::initializer_list<T> l) : rpc_vec() {
     reserve(l.size());
     for (auto v:l) { push_back(v); }
   }
   #endif
 
-  template<size_t m> rpc_vec (const rpc_vec<T, m> &v) { init (); copy (v); }
-  ~rpc_vec () { if (nofree) super::init (); }
-  void clear () { del (); init (); }
+  template<size_t m>
+  SFS_INLINE_VISIBILITY  rpc_vec (const rpc_vec<T, m> &v) { init (); copy (v); }
+  SFS_INLINE_VISIBILITY  ~rpc_vec () { if (nofree) super::init (); }
+  SFS_INLINE_VISIBILITY  void clear () { del (); init (); }
 
   rpc_vec &operator= (const rpc_vec &v) { copy (v); return *this; }
-  template<size_t m> rpc_vec &operator= (const rpc_vec<T, m> &v)
+  template<size_t m>
+  SFS_INLINE_VISIBILITY rpc_vec &operator= (const rpc_vec<T, m> &v)
     { copy (v); return *this; }
-  template<size_t m> rpc_vec &operator= (const ::vec<T, m> &v)
+  template<size_t m>
+  SFS_INLINE_VISIBILITY rpc_vec &operator= (const ::vec<T, m> &v)
     { copy (v.base (), v.size ()); return *this; }
-  template<size_t m> rpc_vec &operator= (const array<T, m> &v)
+  template<size_t m>
+  SFS_INLINE_VISIBILITY rpc_vec &operator= (const array<T, m> &v)
     { switch (0) case 0: case m <= max:; copy (v.base (), m); return *this; }
 
   void swap (rpc_vec &v) {
@@ -196,7 +204,10 @@ public:
   template<size_t m> rpc_vec &set (const ::vec<T, m> &v)
     { set (v.base (), v.size ()); return *this; }
 
-  void reserve (size_t m) { ensure (m); super::reserve (m); }
+  SFS_INLINE_VISIBILITY  void reserve (size_t m) {
+    ensure (m);
+    super::reserve (m);
+  }
 
   void setsize (size_t n) {
     assert (!nofree);
@@ -204,17 +215,21 @@ public:
     super::setsize (n);
   }
 
-  size_t size () const { return super::size (); }
-  bool empty () const { return super::empty (); }
+  SFS_INLINE_VISIBILITY size_t size () const { return super::size (); }
+  SFS_INLINE_VISIBILITY bool empty () const { return super::empty (); }
 
-  elm_t *base () { return super::base (); }
-  const elm_t *base () const { return super::base (); }
+  SFS_INLINE_VISIBILITY elm_t *base () { return super::base (); }
+  SFS_INLINE_VISIBILITY const elm_t *base () const { return super::base (); }
 
-  elm_t *lim () { return super::lim (); }
-  const elm_t *lim () const { return super::lim (); }
+  SFS_INLINE_VISIBILITY  elm_t *lim () { return super::lim (); }
+  SFS_INLINE_VISIBILITY  const elm_t *lim () const { return super::lim (); }
 
-  elm_t &operator[] (size_t i) { return super::operator[] (i); }
-  const elm_t &operator[] (size_t i) const { return super::operator[] (i); }
+  SFS_INLINE_VISIBILITY  elm_t &operator[] (size_t i) {
+    return super::operator[] (i);
+  }
+  SFS_INLINE_VISIBILITY  const elm_t &operator[] (size_t i) const {
+    return super::operator[] (i);
+  }
   elm_t &at (size_t i) { return (*this)[i]; }
   const elm_t &at (size_t i) const { return (*this)[i]; }
 
@@ -241,11 +256,11 @@ do {								\
 
 #undef append
 
-  elm_t &push_back () {
+  SFS_INLINE_VISIBILITY elm_t &push_back () {
     ensure (1);
     return super::push_back ();
   }
-  elm_t &push_back (const elm_t &e) {
+  SFS_INLINE_VISIBILITY elm_t &push_back (const elm_t &e) {
     ensure (1);
     return super::push_back (e);
   }
@@ -639,50 +654,50 @@ extern struct rpc_wipe_t _rpcwipe;
 #define RPC_FIELD const char *field = NULL
 
 inline bool
-rpc_traverse (rpc_clear_t &, u_int32_t &obj, RPC_FIELD)
+SFS_INLINE_VISIBILITY rpc_traverse (rpc_clear_t &, u_int32_t &obj, RPC_FIELD)
 {
   obj = 0;
   return true;
 }
 template<size_t n> inline bool
-rpc_traverse (rpc_clear_t &, rpc_opaque<n> &obj, RPC_FIELD)
+SFS_INLINE_VISIBILITY rpc_traverse (rpc_clear_t &, rpc_opaque<n> &obj, RPC_FIELD)
 {
   bzero (obj.base (), obj.size ());
   return true;
 }
 template<size_t n> inline bool
-rpc_traverse (rpc_wipe_t &, rpc_opaque<n> &obj, RPC_FIELD)
+SFS_INLINE_VISIBILITY rpc_traverse (rpc_wipe_t &, rpc_opaque<n> &obj, RPC_FIELD)
 {
   bzero (obj.base (), obj.size ());
   return true;
 }
 template<size_t n> inline bool
-rpc_traverse (rpc_clear_t &, rpc_bytes<n> &obj, RPC_FIELD)
+SFS_INLINE_VISIBILITY rpc_traverse (rpc_clear_t &, rpc_bytes<n> &obj, RPC_FIELD)
 {
   obj.setsize (0);
   return true;
 }
 template<size_t n> inline bool
-rpc_traverse (rpc_wipe_t &, rpc_bytes<n> &obj, RPC_FIELD)
+SFS_INLINE_VISIBILITY rpc_traverse (rpc_wipe_t &, rpc_bytes<n> &obj, RPC_FIELD)
 {
   bzero (obj.base (), obj.size ());
   obj.setsize (0);
   return true;
 }
 template<size_t n> inline bool
-rpc_traverse (rpc_clear_t &, rpc_str<n> &obj, RPC_FIELD)
+SFS_INLINE_VISIBILITY rpc_traverse (rpc_clear_t &, rpc_str<n> &obj, RPC_FIELD)
 {
   obj = "";
   return true;
 }
 template<class T> inline bool
-rpc_traverse (rpc_clear_t &, rpc_ptr<T> &obj, RPC_FIELD)
+SFS_INLINE_VISIBILITY rpc_traverse (rpc_clear_t &, rpc_ptr<T> &obj, RPC_FIELD)
 {
   obj.clear ();
   return true;
 }
 template<class T> inline bool
-rpc_traverse (rpc_wipe_t &t, rpc_ptr<T> &obj, RPC_FIELD)
+SFS_INLINE_VISIBILITY rpc_traverse (rpc_wipe_t &t, rpc_ptr<T> &obj, RPC_FIELD)
 {
   if (obj)
     rpc_traverse (t, *obj);
@@ -690,7 +705,7 @@ rpc_traverse (rpc_wipe_t &t, rpc_ptr<T> &obj, RPC_FIELD)
   return true;
 }
 template<class T, size_t n> inline bool
-rpc_traverse (rpc_clear_t &, rpc_vec<T, n> &obj, RPC_FIELD)
+SFS_INLINE_VISIBILITY rpc_traverse (rpc_clear_t &, rpc_vec<T, n> &obj, RPC_FIELD)
 {
   obj.setsize (0);
   return true;

--- a/async/Makefile.am
+++ b/async/Makefile.am
@@ -29,7 +29,7 @@ parseopt.h qhash.h refcnt.h rxx.h serial.h stllike.h str.h	\
 suio++.h sysconf.h union.h vatmpl.h vec.h rwfd.h litetime.h       	\
 corebench.h qtailq.h sfs_select.h rclist.h dynenum.h         \
 rctailq.h rctree.h sfs_bundle.h alog2.h sfs_profiler.h wide_str.h 	\
-sfs_const.h sfs_assert.h weak_template.h
+sfs_const.h sfs_assert.h sfs_attr.h weak_template.h
 
 #
 # begin sfslite changes

--- a/async/callback.h
+++ b/async/callback.h
@@ -192,9 +192,10 @@ public:
     : dest (df[0] == '&' ? df + 1 : df), src (f), line (l) {}
 $enddebug
   virtual R operator() ($cbdecl) = 0;
-  virtual void trigger ($cbdecl) { (void) (*this) ($cbargs); }
-  virtual ~callback () {}
-  callback () : _closure_type (NULL), _closure_void (NULL) {}
+  virtual SFS_INLINE_VISIBILITY void trigger ($cbdecl) { (void) (*this) ($cbargs); }
+  virtual SFS_INLINE_VISIBILITY ~callback () {}
+  SFS_INLINE_VISIBILITY callback () : _closure_type (NULL), _closure_void (NULL)
+  {}
   void set_gdb_info (const char *typ, const void *v)
     { _closure_type = typ; _closure_void = v; }
 };
@@ -256,10 +257,11 @@ class $type
   typedef R (*cb_t) ($ABlist);
   cb_t f;
 ${adecl}public:
-  $type (callback_line_param $aargs)
+  SFS_INLINE_VISIBILITY $type (callback_line_param $aargs)
     : callback_line_init (callback<$RBlist>) $ainit {}
-  R operator() ($bargs)
+  SFS_INLINE_VISIBILITY R operator() ($bargs)
     { return f ($ablist); }
+  SFS_INLINE_VISIBILITY ~$type() {}
 };
 EOF
 
@@ -277,10 +279,11 @@ class $type<$specargs>
   typedef void (*cb_t) ($ABlist);
   cb_t f;
 ${adecl}public:
-  $type (callback_line_param $aargs)
+  SFS_INLINE_VISIBILITY $type (callback_line_param $aargs)
     : callback_line_init (callback<$RBlist>) $ainit {}
-  void operator() ($bargs)
+  SFS_INLINE_VISIBILITY void operator() ($bargs)
     { f ($ablist); }
+  SFS_INLINE_VISIBILITY ~$type() {}
 };
 EOF
 }
@@ -324,10 +327,11 @@ public:
     }
 #else $bc !WRAP_USE_NODELETE $ec
 ${adecl}public:
-  $type (callback_line_param $aargs)
+  SFS_INLINE_VISIBILITY $type (callback_line_param $aargs)
     : callback_line_init (callback<$RBlist>) $ainit {}
-  R operator() ($bargs)
+  SFS_INLINE_VISIBILITY R operator() ($bargs)
     { return ((*c).*f) ($ablist); }
+  SFS_INLINE_VISIBILITY ~$type () {}
 #endif $bc !WRAP_USE_NODELETE $ec
 };
 EOF
@@ -348,10 +352,11 @@ class $type<$specargs>
   P c;
   cb_t f;
 ${adecl}public:
-  $type (callback_line_param $aargs)
+  SFS_INLINE_VISIBILITY $type (callback_line_param $aargs)
     : callback_line_init (callback<$RBlist>) $ainit {}
-  void operator() ($bargs)
+  SFS_INLINE_VISIBILITY void operator() ($bargs)
     { ((*c).*f) ($ablist); }
+  SFS_INLINE_VISIBILITY ~$type() {}
 };
 EOF
 }
@@ -369,7 +374,7 @@ sub pwrap_b_a ($$) {
     print <<"EOF";
 
 template<$tmpparam>
-static inline $rtype *
+static SFS_INLINE_VISIBILITY inline $rtype *
 wrap (wrap_line_param $fargs)
 {
   return wNew ($rtype) (wrap_line_arg $falist);
@@ -392,7 +397,7 @@ sub pwrap_c_b_a ($$$) {
     print <<"EOF";
 
 template<$tmpparam>
-static inline $rtype *
+static SFS_INLINE_VISIBILITY inline $rtype *
 wrap (wrap_line_param $fargs)
 {
   return wNew ($rtype) (wrap_c_line_arg $falist);
@@ -412,19 +417,19 @@ EOF
     print <<"EOF";
 
 template<$tmpparam>
-static inline $rtype *
+static SFS_INLINE_VISIBILITY inline $rtype *
 wrap (wrap_line_param $fargs)
 {
   return wNew ($rtype) (wrap_c_line_arg $falist);
 }
 template<$tmpparam>
-static inline $rtype *
+static SFS_INLINE_VISIBILITY inline $rtype *
 wrap (wrap_line_param $f2args)
 {
   return wNew ($rtype) (wrap_c_line_arg $falist);
 }
 template<$tmpparam>
-static inline $rtype *
+static SFS_INLINE_VISIBILITY inline $rtype *
 wrap (wrap_line_param $f3args)
 {
   return wNew ($rtype) (wrap_c_line_arg $falist);
@@ -704,9 +709,10 @@ public:
     : dest (df[0] == '&' ? df + 1 : df), src (f), line (l) {}
 #endif /* WRAP_DEBUG */
   virtual R operator() () = 0;
-  virtual void trigger () { (void) (*this) (); }
-  virtual ~callback () {}
-  callback () : _closure_type (NULL), _closure_void (NULL) {}
+  virtual SFS_INLINE_VISIBILITY void trigger () { (void) (*this) (); }
+  virtual SFS_INLINE_VISIBILITY ~callback () {}
+  SFS_INLINE_VISIBILITY callback () : _closure_type (NULL), _closure_void (NULL)
+  {}
   void set_gdb_info (const char *typ, const void *v)
     { _closure_type = typ; _closure_void = v; }
 };
@@ -718,14 +724,15 @@ class callback_0_0
   typedef R (*cb_t) ();
   cb_t f;
 public:
-  callback_0_0 (callback_line_param cb_t ff)
+  SFS_INLINE_VISIBILITY callback_0_0 (callback_line_param cb_t ff)
     : callback_line_init (callback<R>) f (ff) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return f (); }
+  SFS_INLINE_VISIBILITY ~callback_0_0() {}
 };
 
 template<class R>
-static inline refcounted<callback_0_0<R> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_0_0<R> > *
 wrap (wrap_line_param R (*f) ())
 {
   return wNew (refcounted<callback_0_0<R> >) (wrap_line_arg f);
@@ -754,10 +761,11 @@ public:
     }
 #else /* !WRAP_USE_NODELETE */
 public:
-  callback_c_0_0 (callback_line_param const P &cc, cb_t ff)
+  SFS_INLINE_VISIBILITY callback_c_0_0 (callback_line_param const P &cc, cb_t ff)
     : callback_line_init (callback<R>) c (cc), f (ff) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_0 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -784,60 +792,61 @@ public:
     }
 #else /* !WRAP_USE_NODELETE */
 public:
-  callback_c_0_0_const (callback_line_param const P &cc, cb_t ff)
+  SFS_INLINE_VISIBILITY callback_c_0_0_const (callback_line_param const P &cc, cb_t ff)
     : callback_line_init (callback<R>) c (cc), f (ff) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_0_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R>
-static inline refcounted<callback_c_0_0< C *, C, R> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_0< C *, C, R> > *
 wrap (wrap_line_param  C *p, R (C::*f) () )
 {
   return wNew (refcounted<callback_c_0_0< C *, C, R> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R>
-static inline refcounted<callback_c_0_0<ref< C>,  C, R> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_0<ref< C>,  C, R> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) () )
 {
   return wNew (refcounted<callback_c_0_0<ref< C>,  C, R> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R>
-static inline refcounted<callback_c_0_0<ref< C>,  C, R> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_0<ref< C>,  C, R> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) () )
 {
   return wNew (refcounted<callback_c_0_0<ref< C>,  C, R> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R>
-static inline refcounted<callback_c_0_0<ref< C>,  C, R> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_0<ref< C>,  C, R> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) () )
 {
   return wNew (refcounted<callback_c_0_0<ref< C>,  C, R> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R>
-static inline refcounted<callback_c_0_0_const<const C *, C, R> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_0_const<const C *, C, R> > *
 wrap (wrap_line_param const C *p, R (C::*f) () const)
 {
   return wNew (refcounted<callback_c_0_0_const<const C *, C, R> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R>
-static inline refcounted<callback_c_0_0_const<ref<const C>, const C, R> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_0_const<ref<const C>, const C, R> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) () const)
 {
   return wNew (refcounted<callback_c_0_0_const<ref<const C>, const C, R> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R>
-static inline refcounted<callback_c_0_0_const<ref<const C>, const C, R> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_0_const<ref<const C>, const C, R> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) () const)
 {
   return wNew (refcounted<callback_c_0_0_const<ref<const C>, const C, R> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R>
-static inline refcounted<callback_c_0_0_const<ref<const C>, const C, R> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_0_const<ref<const C>, const C, R> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) () const)
 {
   return wNew (refcounted<callback_c_0_0_const<ref<const C>, const C, R> >) (wrap_c_line_arg p, f);
@@ -850,14 +859,15 @@ class callback_0_1
   cb_t f;
   A1 a1;
 public:
-  callback_0_1 (callback_line_param cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_0_1 (callback_line_param cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R>) f (ff), a1 (aa1) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return f (a1); }
+  SFS_INLINE_VISIBILITY ~callback_0_1() {}
 };
 
 template<class R, class A1, class AA1>
-static inline refcounted<callback_0_1<R, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_0_1<R, A1> > *
 wrap (wrap_line_param R (*f) (A1), const AA1 &a1)
 {
   return wNew (refcounted<callback_0_1<R, A1> >) (wrap_line_arg f, a1);
@@ -888,10 +898,11 @@ public:
 #else /* !WRAP_USE_NODELETE */
   A1 a1;
 public:
-  callback_c_0_1 (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_c_0_1 (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R>) c (cc), f (ff), a1 (aa1) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (a1); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_1 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -920,60 +931,61 @@ public:
 #else /* !WRAP_USE_NODELETE */
   A1 a1;
 public:
-  callback_c_0_1_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_c_0_1_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R>) c (cc), f (ff), a1 (aa1) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (a1); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_1_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class A1, class AA1>
-static inline refcounted<callback_c_0_1< C *, C, R, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_1< C *, C, R, A1> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_0_1< C *, C, R, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class A1, class AA1>
-static inline refcounted<callback_c_0_1<ref< C>,  C, R, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_1<ref< C>,  C, R, A1> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_0_1<ref< C>,  C, R, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class A1, class AA1>
-static inline refcounted<callback_c_0_1<ref< C>,  C, R, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_1<ref< C>,  C, R, A1> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_0_1<ref< C>,  C, R, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class A1, class AA1>
-static inline refcounted<callback_c_0_1<ref< C>,  C, R, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_1<ref< C>,  C, R, A1> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_0_1<ref< C>,  C, R, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class A1, class AA1>
-static inline refcounted<callback_c_0_1_const<const C *, C, R, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_1_const<const C *, C, R, A1> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_0_1_const<const C *, C, R, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class A1, class AA1>
-static inline refcounted<callback_c_0_1_const<ref<const C>, const C, R, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_1_const<ref<const C>, const C, R, A1> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_0_1_const<ref<const C>, const C, R, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class A1, class AA1>
-static inline refcounted<callback_c_0_1_const<ref<const C>, const C, R, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_1_const<ref<const C>, const C, R, A1> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_0_1_const<ref<const C>, const C, R, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class A1, class AA1>
-static inline refcounted<callback_c_0_1_const<ref<const C>, const C, R, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_1_const<ref<const C>, const C, R, A1> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_0_1_const<ref<const C>, const C, R, A1> >) (wrap_c_line_arg p, f, a1);
@@ -987,14 +999,15 @@ class callback_0_2
   A1 a1;
   A2 a2;
 public:
-  callback_0_2 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_0_2 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R>) f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return f (a1, a2); }
+  SFS_INLINE_VISIBILITY ~callback_0_2() {}
 };
 
 template<class R, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_0_2<R, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_0_2<R, A1, A2> > *
 wrap (wrap_line_param R (*f) (A1, A2), const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_0_2<R, A1, A2> >) (wrap_line_arg f, a1, a2);
@@ -1027,10 +1040,11 @@ public:
   A1 a1;
   A2 a2;
 public:
-  callback_c_0_2 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_c_0_2 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R>) c (cc), f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (a1, a2); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_2 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -1061,60 +1075,61 @@ public:
   A1 a1;
   A2 a2;
 public:
-  callback_c_0_2_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_c_0_2_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R>) c (cc), f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (a1, a2); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_2_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_0_2< C *, C, R, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_2< C *, C, R, A1, A2> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_0_2< C *, C, R, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_0_2<ref< C>,  C, R, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_2<ref< C>,  C, R, A1, A2> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_0_2<ref< C>,  C, R, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_0_2<ref< C>,  C, R, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_2<ref< C>,  C, R, A1, A2> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_0_2<ref< C>,  C, R, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_0_2<ref< C>,  C, R, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_2<ref< C>,  C, R, A1, A2> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_0_2<ref< C>,  C, R, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_0_2_const<const C *, C, R, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_2_const<const C *, C, R, A1, A2> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_0_2_const<const C *, C, R, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_0_2_const<ref<const C>, const C, R, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_2_const<ref<const C>, const C, R, A1, A2> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_0_2_const<ref<const C>, const C, R, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_0_2_const<ref<const C>, const C, R, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_2_const<ref<const C>, const C, R, A1, A2> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_0_2_const<ref<const C>, const C, R, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_0_2_const<ref<const C>, const C, R, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_2_const<ref<const C>, const C, R, A1, A2> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_0_2_const<ref<const C>, const C, R, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
@@ -1129,14 +1144,15 @@ class callback_0_3
   A2 a2;
   A3 a3;
 public:
-  callback_0_3 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_0_3 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return f (a1, a2, a3); }
+  SFS_INLINE_VISIBILITY ~callback_0_3() {}
 };
 
 template<class R, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_0_3<R, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_0_3<R, A1, A2, A3> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3), const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_0_3<R, A1, A2, A3> >) (wrap_line_arg f, a1, a2, a3);
@@ -1171,10 +1187,11 @@ public:
   A2 a2;
   A3 a3;
 public:
-  callback_c_0_3 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_c_0_3 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (a1, a2, a3); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_3 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -1207,60 +1224,61 @@ public:
   A2 a2;
   A3 a3;
 public:
-  callback_c_0_3_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_c_0_3_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (a1, a2, a3); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_3_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_0_3< C *, C, R, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_3< C *, C, R, A1, A2, A3> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_0_3< C *, C, R, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_0_3<ref< C>,  C, R, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_3<ref< C>,  C, R, A1, A2, A3> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_0_3<ref< C>,  C, R, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_0_3<ref< C>,  C, R, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_3<ref< C>,  C, R, A1, A2, A3> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_0_3<ref< C>,  C, R, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_0_3<ref< C>,  C, R, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_3<ref< C>,  C, R, A1, A2, A3> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_0_3<ref< C>,  C, R, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_0_3_const<const C *, C, R, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_3_const<const C *, C, R, A1, A2, A3> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_0_3_const<const C *, C, R, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_0_3_const<ref<const C>, const C, R, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_3_const<ref<const C>, const C, R, A1, A2, A3> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_0_3_const<ref<const C>, const C, R, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_0_3_const<ref<const C>, const C, R, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_3_const<ref<const C>, const C, R, A1, A2, A3> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_0_3_const<ref<const C>, const C, R, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_0_3_const<ref<const C>, const C, R, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_3_const<ref<const C>, const C, R, A1, A2, A3> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_0_3_const<ref<const C>, const C, R, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
@@ -1277,14 +1295,15 @@ class callback_0_4
   A3 a3;
   A4 a4;
 public:
-  callback_0_4 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_0_4 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return f (a1, a2, a3, a4); }
+  SFS_INLINE_VISIBILITY ~callback_0_4() {}
 };
 
 template<class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_0_4<R, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_0_4<R, A1, A2, A3, A4> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, A4), const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_0_4<R, A1, A2, A3, A4> >) (wrap_line_arg f, a1, a2, a3, a4);
@@ -1321,10 +1340,11 @@ public:
   A3 a3;
   A4 a4;
 public:
-  callback_c_0_4 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_c_0_4 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (a1, a2, a3, a4); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_4 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -1359,60 +1379,61 @@ public:
   A3 a3;
   A4 a4;
 public:
-  callback_c_0_4_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_c_0_4_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (a1, a2, a3, a4); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_4_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_0_4< C *, C, R, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_4< C *, C, R, A1, A2, A3, A4> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, A4) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_0_4< C *, C, R, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_0_4<ref< C>,  C, R, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_4<ref< C>,  C, R, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, A4) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_0_4<ref< C>,  C, R, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_0_4<ref< C>,  C, R, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_4<ref< C>,  C, R, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, A4) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_0_4<ref< C>,  C, R, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_0_4<ref< C>,  C, R, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_4<ref< C>,  C, R, A1, A2, A3, A4> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, A4) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_0_4<ref< C>,  C, R, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_0_4_const<const C *, C, R, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_4_const<const C *, C, R, A1, A2, A3, A4> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, A4) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_0_4_const<const C *, C, R, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_0_4_const<ref<const C>, const C, R, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_4_const<ref<const C>, const C, R, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, A4) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_0_4_const<ref<const C>, const C, R, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_0_4_const<ref<const C>, const C, R, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_4_const<ref<const C>, const C, R, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, A4) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_0_4_const<ref<const C>, const C, R, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_0_4_const<ref<const C>, const C, R, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_4_const<ref<const C>, const C, R, A1, A2, A3, A4> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, A4) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_0_4_const<ref<const C>, const C, R, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
@@ -1432,14 +1453,15 @@ class callback_0_5
   A4 a4;
   A5 a5;
 public:
-  callback_0_5 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_0_5 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return f (a1, a2, a3, a4, a5); }
+  SFS_INLINE_VISIBILITY ~callback_0_5() {}
 };
 
 template<class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_0_5<R, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_0_5<R, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, A4, A5), const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_0_5<R, A1, A2, A3, A4, A5> >) (wrap_line_arg f, a1, a2, a3, a4, a5);
@@ -1478,10 +1500,11 @@ public:
   A4 a4;
   A5 a5;
 public:
-  callback_c_0_5 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_c_0_5 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (a1, a2, a3, a4, a5); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_5 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -1518,60 +1541,61 @@ public:
   A4 a4;
   A5 a5;
 public:
-  callback_c_0_5_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_c_0_5_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() ()
+  SFS_INLINE_VISIBILITY R operator() ()
     { return ((*c).*f) (a1, a2, a3, a4, a5); }
+  SFS_INLINE_VISIBILITY ~callback_c_0_5_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_0_5< C *, C, R, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_5< C *, C, R, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, A4, A5) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_0_5< C *, C, R, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_0_5<ref< C>,  C, R, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_5<ref< C>,  C, R, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, A4, A5) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_0_5<ref< C>,  C, R, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_0_5<ref< C>,  C, R, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_5<ref< C>,  C, R, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, A4, A5) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_0_5<ref< C>,  C, R, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_0_5<ref< C>,  C, R, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_5<ref< C>,  C, R, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, A4, A5) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_0_5<ref< C>,  C, R, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_0_5_const<const C *, C, R, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_5_const<const C *, C, R, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, A4, A5) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_0_5_const<const C *, C, R, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_0_5_const<ref<const C>, const C, R, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_5_const<ref<const C>, const C, R, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, A4, A5) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_0_5_const<ref<const C>, const C, R, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_0_5_const<ref<const C>, const C, R, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_5_const<ref<const C>, const C, R, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, A4, A5) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_0_5_const<ref<const C>, const C, R, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_0_5_const<ref<const C>, const C, R, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_0_5_const<ref<const C>, const C, R, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, A4, A5) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_0_5_const<ref<const C>, const C, R, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
@@ -1596,9 +1620,10 @@ public:
     : dest (df[0] == '&' ? df + 1 : df), src (f), line (l) {}
 #endif /* WRAP_DEBUG */
   virtual R operator() (B1 b1) = 0;
-  virtual void trigger (B1 b1) { (void) (*this) (b1); }
-  virtual ~callback () {}
-  callback () : _closure_type (NULL), _closure_void (NULL) {}
+  virtual SFS_INLINE_VISIBILITY void trigger (B1 b1) { (void) (*this) (b1); }
+  virtual SFS_INLINE_VISIBILITY ~callback () {}
+  SFS_INLINE_VISIBILITY callback () : _closure_type (NULL), _closure_void (NULL)
+  {}
   void set_gdb_info (const char *typ, const void *v)
     { _closure_type = typ; _closure_void = v; }
 };
@@ -1610,14 +1635,15 @@ class callback_1_0
   typedef R (*cb_t) (B1);
   cb_t f;
 public:
-  callback_1_0 (callback_line_param cb_t ff)
+  SFS_INLINE_VISIBILITY callback_1_0 (callback_line_param cb_t ff)
     : callback_line_init (callback<R, B1>) f (ff) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return f (b1); }
+  SFS_INLINE_VISIBILITY ~callback_1_0() {}
 };
 
 template<class R, class B1>
-static inline refcounted<callback_1_0<R, B1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_1_0<R, B1> > *
 wrap (wrap_line_param R (*f) (B1))
 {
   return wNew (refcounted<callback_1_0<R, B1> >) (wrap_line_arg f);
@@ -1646,10 +1672,11 @@ public:
     }
 #else /* !WRAP_USE_NODELETE */
 public:
-  callback_c_1_0 (callback_line_param const P &cc, cb_t ff)
+  SFS_INLINE_VISIBILITY callback_c_1_0 (callback_line_param const P &cc, cb_t ff)
     : callback_line_init (callback<R, B1>) c (cc), f (ff) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_0 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -1676,60 +1703,61 @@ public:
     }
 #else /* !WRAP_USE_NODELETE */
 public:
-  callback_c_1_0_const (callback_line_param const P &cc, cb_t ff)
+  SFS_INLINE_VISIBILITY callback_c_1_0_const (callback_line_param const P &cc, cb_t ff)
     : callback_line_init (callback<R, B1>) c (cc), f (ff) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_0_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1>
-static inline refcounted<callback_c_1_0< C *, C, R, B1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_0< C *, C, R, B1> > *
 wrap (wrap_line_param  C *p, R (C::*f) (B1) )
 {
   return wNew (refcounted<callback_c_1_0< C *, C, R, B1> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R, class B1>
-static inline refcounted<callback_c_1_0<ref< C>,  C, R, B1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_0<ref< C>,  C, R, B1> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (B1) )
 {
   return wNew (refcounted<callback_c_1_0<ref< C>,  C, R, B1> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1>
-static inline refcounted<callback_c_1_0<ref< C>,  C, R, B1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_0<ref< C>,  C, R, B1> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (B1) )
 {
   return wNew (refcounted<callback_c_1_0<ref< C>,  C, R, B1> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1>
-static inline refcounted<callback_c_1_0<ref< C>,  C, R, B1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_0<ref< C>,  C, R, B1> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (B1) )
 {
   return wNew (refcounted<callback_c_1_0<ref< C>,  C, R, B1> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R, class B1>
-static inline refcounted<callback_c_1_0_const<const C *, C, R, B1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_0_const<const C *, C, R, B1> > *
 wrap (wrap_line_param const C *p, R (C::*f) (B1) const)
 {
   return wNew (refcounted<callback_c_1_0_const<const C *, C, R, B1> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R, class B1>
-static inline refcounted<callback_c_1_0_const<ref<const C>, const C, R, B1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_0_const<ref<const C>, const C, R, B1> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (B1) const)
 {
   return wNew (refcounted<callback_c_1_0_const<ref<const C>, const C, R, B1> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1>
-static inline refcounted<callback_c_1_0_const<ref<const C>, const C, R, B1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_0_const<ref<const C>, const C, R, B1> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (B1) const)
 {
   return wNew (refcounted<callback_c_1_0_const<ref<const C>, const C, R, B1> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1>
-static inline refcounted<callback_c_1_0_const<ref<const C>, const C, R, B1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_0_const<ref<const C>, const C, R, B1> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (B1) const)
 {
   return wNew (refcounted<callback_c_1_0_const<ref<const C>, const C, R, B1> >) (wrap_c_line_arg p, f);
@@ -1742,14 +1770,15 @@ class callback_1_1
   cb_t f;
   A1 a1;
 public:
-  callback_1_1 (callback_line_param cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_1_1 (callback_line_param cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R, B1>) f (ff), a1 (aa1) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return f (a1, b1); }
+  SFS_INLINE_VISIBILITY ~callback_1_1() {}
 };
 
 template<class R, class B1, class A1, class AA1>
-static inline refcounted<callback_1_1<R, B1, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_1_1<R, B1, A1> > *
 wrap (wrap_line_param R (*f) (A1, B1), const AA1 &a1)
 {
   return wNew (refcounted<callback_1_1<R, B1, A1> >) (wrap_line_arg f, a1);
@@ -1780,10 +1809,11 @@ public:
 #else /* !WRAP_USE_NODELETE */
   A1 a1;
 public:
-  callback_c_1_1 (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_c_1_1 (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R, B1>) c (cc), f (ff), a1 (aa1) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (a1, b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_1 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -1812,60 +1842,61 @@ public:
 #else /* !WRAP_USE_NODELETE */
   A1 a1;
 public:
-  callback_c_1_1_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_c_1_1_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R, B1>) c (cc), f (ff), a1 (aa1) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (a1, b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_1_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class A1, class AA1>
-static inline refcounted<callback_c_1_1< C *, C, R, B1, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_1< C *, C, R, B1, A1> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, B1) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_1_1< C *, C, R, B1, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class B1, class A1, class AA1>
-static inline refcounted<callback_c_1_1<ref< C>,  C, R, B1, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_1<ref< C>,  C, R, B1, A1> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, B1) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_1_1<ref< C>,  C, R, B1, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class A1, class AA1>
-static inline refcounted<callback_c_1_1<ref< C>,  C, R, B1, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_1<ref< C>,  C, R, B1, A1> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, B1) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_1_1<ref< C>,  C, R, B1, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class A1, class AA1>
-static inline refcounted<callback_c_1_1<ref< C>,  C, R, B1, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_1<ref< C>,  C, R, B1, A1> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, B1) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_1_1<ref< C>,  C, R, B1, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class B1, class A1, class AA1>
-static inline refcounted<callback_c_1_1_const<const C *, C, R, B1, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_1_const<const C *, C, R, B1, A1> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, B1) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_1_1_const<const C *, C, R, B1, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class B1, class A1, class AA1>
-static inline refcounted<callback_c_1_1_const<ref<const C>, const C, R, B1, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_1_const<ref<const C>, const C, R, B1, A1> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, B1) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_1_1_const<ref<const C>, const C, R, B1, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class A1, class AA1>
-static inline refcounted<callback_c_1_1_const<ref<const C>, const C, R, B1, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_1_const<ref<const C>, const C, R, B1, A1> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, B1) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_1_1_const<ref<const C>, const C, R, B1, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class A1, class AA1>
-static inline refcounted<callback_c_1_1_const<ref<const C>, const C, R, B1, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_1_const<ref<const C>, const C, R, B1, A1> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, B1) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_1_1_const<ref<const C>, const C, R, B1, A1> >) (wrap_c_line_arg p, f, a1);
@@ -1879,14 +1910,15 @@ class callback_1_2
   A1 a1;
   A2 a2;
 public:
-  callback_1_2 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_1_2 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R, B1>) f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return f (a1, a2, b1); }
+  SFS_INLINE_VISIBILITY ~callback_1_2() {}
 };
 
 template<class R, class B1, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_1_2<R, B1, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_1_2<R, B1, A1, A2> > *
 wrap (wrap_line_param R (*f) (A1, A2, B1), const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_1_2<R, B1, A1, A2> >) (wrap_line_arg f, a1, a2);
@@ -1919,10 +1951,11 @@ public:
   A1 a1;
   A2 a2;
 public:
-  callback_c_1_2 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_c_1_2 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R, B1>) c (cc), f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (a1, a2, b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_2 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -1953,60 +1986,61 @@ public:
   A1 a1;
   A2 a2;
 public:
-  callback_c_1_2_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_c_1_2_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R, B1>) c (cc), f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (a1, a2, b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_2_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_1_2< C *, C, R, B1, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_2< C *, C, R, B1, A1, A2> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, B1) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_1_2< C *, C, R, B1, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_1_2<ref< C>,  C, R, B1, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_2<ref< C>,  C, R, B1, A1, A2> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, B1) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_1_2<ref< C>,  C, R, B1, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_1_2<ref< C>,  C, R, B1, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_2<ref< C>,  C, R, B1, A1, A2> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, B1) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_1_2<ref< C>,  C, R, B1, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_1_2<ref< C>,  C, R, B1, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_2<ref< C>,  C, R, B1, A1, A2> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, B1) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_1_2<ref< C>,  C, R, B1, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_1_2_const<const C *, C, R, B1, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_2_const<const C *, C, R, B1, A1, A2> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, B1) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_1_2_const<const C *, C, R, B1, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_1_2_const<ref<const C>, const C, R, B1, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_2_const<ref<const C>, const C, R, B1, A1, A2> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, B1) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_1_2_const<ref<const C>, const C, R, B1, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_1_2_const<ref<const C>, const C, R, B1, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_2_const<ref<const C>, const C, R, B1, A1, A2> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, B1) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_1_2_const<ref<const C>, const C, R, B1, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_1_2_const<ref<const C>, const C, R, B1, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_2_const<ref<const C>, const C, R, B1, A1, A2> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, B1) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_1_2_const<ref<const C>, const C, R, B1, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
@@ -2021,14 +2055,15 @@ class callback_1_3
   A2 a2;
   A3 a3;
 public:
-  callback_1_3 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_1_3 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R, B1>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return f (a1, a2, a3, b1); }
+  SFS_INLINE_VISIBILITY ~callback_1_3() {}
 };
 
 template<class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_1_3<R, B1, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_1_3<R, B1, A1, A2, A3> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, B1), const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_1_3<R, B1, A1, A2, A3> >) (wrap_line_arg f, a1, a2, a3);
@@ -2063,10 +2098,11 @@ public:
   A2 a2;
   A3 a3;
 public:
-  callback_c_1_3 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_c_1_3 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R, B1>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (a1, a2, a3, b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_3 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -2099,60 +2135,61 @@ public:
   A2 a2;
   A3 a3;
 public:
-  callback_c_1_3_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_c_1_3_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R, B1>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (a1, a2, a3, b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_3_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_1_3< C *, C, R, B1, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_3< C *, C, R, B1, A1, A2, A3> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_1_3< C *, C, R, B1, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_1_3<ref< C>,  C, R, B1, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_3<ref< C>,  C, R, B1, A1, A2, A3> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_1_3<ref< C>,  C, R, B1, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_1_3<ref< C>,  C, R, B1, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_3<ref< C>,  C, R, B1, A1, A2, A3> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_1_3<ref< C>,  C, R, B1, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_1_3<ref< C>,  C, R, B1, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_3<ref< C>,  C, R, B1, A1, A2, A3> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_1_3<ref< C>,  C, R, B1, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_1_3_const<const C *, C, R, B1, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_3_const<const C *, C, R, B1, A1, A2, A3> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_1_3_const<const C *, C, R, B1, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_1_3_const<ref<const C>, const C, R, B1, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_3_const<ref<const C>, const C, R, B1, A1, A2, A3> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_1_3_const<ref<const C>, const C, R, B1, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_1_3_const<ref<const C>, const C, R, B1, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_3_const<ref<const C>, const C, R, B1, A1, A2, A3> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_1_3_const<ref<const C>, const C, R, B1, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_1_3_const<ref<const C>, const C, R, B1, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_3_const<ref<const C>, const C, R, B1, A1, A2, A3> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_1_3_const<ref<const C>, const C, R, B1, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
@@ -2169,14 +2206,15 @@ class callback_1_4
   A3 a3;
   A4 a4;
 public:
-  callback_1_4 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_1_4 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R, B1>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return f (a1, a2, a3, a4, b1); }
+  SFS_INLINE_VISIBILITY ~callback_1_4() {}
 };
 
 template<class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_1_4<R, B1, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_1_4<R, B1, A1, A2, A3, A4> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, A4, B1), const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_1_4<R, B1, A1, A2, A3, A4> >) (wrap_line_arg f, a1, a2, a3, a4);
@@ -2213,10 +2251,11 @@ public:
   A3 a3;
   A4 a4;
 public:
-  callback_c_1_4 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_c_1_4 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R, B1>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (a1, a2, a3, a4, b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_4 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -2251,60 +2290,61 @@ public:
   A3 a3;
   A4 a4;
 public:
-  callback_c_1_4_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_c_1_4_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R, B1>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (a1, a2, a3, a4, b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_4_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_1_4< C *, C, R, B1, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_4< C *, C, R, B1, A1, A2, A3, A4> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, A4, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_1_4< C *, C, R, B1, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_1_4<ref< C>,  C, R, B1, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_4<ref< C>,  C, R, B1, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, A4, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_1_4<ref< C>,  C, R, B1, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_1_4<ref< C>,  C, R, B1, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_4<ref< C>,  C, R, B1, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, A4, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_1_4<ref< C>,  C, R, B1, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_1_4<ref< C>,  C, R, B1, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_4<ref< C>,  C, R, B1, A1, A2, A3, A4> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, A4, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_1_4<ref< C>,  C, R, B1, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_1_4_const<const C *, C, R, B1, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_4_const<const C *, C, R, B1, A1, A2, A3, A4> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, A4, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_1_4_const<const C *, C, R, B1, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_1_4_const<ref<const C>, const C, R, B1, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_4_const<ref<const C>, const C, R, B1, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, A4, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_1_4_const<ref<const C>, const C, R, B1, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_1_4_const<ref<const C>, const C, R, B1, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_4_const<ref<const C>, const C, R, B1, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, A4, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_1_4_const<ref<const C>, const C, R, B1, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_1_4_const<ref<const C>, const C, R, B1, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_4_const<ref<const C>, const C, R, B1, A1, A2, A3, A4> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, A4, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_1_4_const<ref<const C>, const C, R, B1, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
@@ -2324,14 +2364,15 @@ class callback_1_5
   A4 a4;
   A5 a5;
 public:
-  callback_1_5 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_1_5 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R, B1>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return f (a1, a2, a3, a4, a5, b1); }
+  SFS_INLINE_VISIBILITY ~callback_1_5() {}
 };
 
 template<class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_1_5<R, B1, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_1_5<R, B1, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, A4, A5, B1), const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_1_5<R, B1, A1, A2, A3, A4, A5> >) (wrap_line_arg f, a1, a2, a3, a4, a5);
@@ -2370,10 +2411,11 @@ public:
   A4 a4;
   A5 a5;
 public:
-  callback_c_1_5 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_c_1_5 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R, B1>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (a1, a2, a3, a4, a5, b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_5 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -2410,60 +2452,61 @@ public:
   A4 a4;
   A5 a5;
 public:
-  callback_c_1_5_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_c_1_5_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R, B1>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() (B1 b1)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1)
     { return ((*c).*f) (a1, a2, a3, a4, a5, b1); }
+  SFS_INLINE_VISIBILITY ~callback_c_1_5_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_1_5< C *, C, R, B1, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_5< C *, C, R, B1, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, A4, A5, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_1_5< C *, C, R, B1, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_1_5<ref< C>,  C, R, B1, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_5<ref< C>,  C, R, B1, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_1_5<ref< C>,  C, R, B1, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_1_5<ref< C>,  C, R, B1, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_5<ref< C>,  C, R, B1, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_1_5<ref< C>,  C, R, B1, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_1_5<ref< C>,  C, R, B1, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_5<ref< C>,  C, R, B1, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, A4, A5, B1) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_1_5<ref< C>,  C, R, B1, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_1_5_const<const C *, C, R, B1, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_5_const<const C *, C, R, B1, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, A4, A5, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_1_5_const<const C *, C, R, B1, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_1_5_const<ref<const C>, const C, R, B1, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_5_const<ref<const C>, const C, R, B1, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_1_5_const<ref<const C>, const C, R, B1, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_1_5_const<ref<const C>, const C, R, B1, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_5_const<ref<const C>, const C, R, B1, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_1_5_const<ref<const C>, const C, R, B1, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_1_5_const<ref<const C>, const C, R, B1, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_1_5_const<ref<const C>, const C, R, B1, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, A4, A5, B1) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_1_5_const<ref<const C>, const C, R, B1, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
@@ -2488,9 +2531,10 @@ public:
     : dest (df[0] == '&' ? df + 1 : df), src (f), line (l) {}
 #endif /* WRAP_DEBUG */
   virtual R operator() (B1 b1, B2 b2) = 0;
-  virtual void trigger (B1 b1, B2 b2) { (void) (*this) (b1, b2); }
-  virtual ~callback () {}
-  callback () : _closure_type (NULL), _closure_void (NULL) {}
+  virtual SFS_INLINE_VISIBILITY void trigger (B1 b1, B2 b2) { (void) (*this) (b1, b2); }
+  virtual SFS_INLINE_VISIBILITY ~callback () {}
+  SFS_INLINE_VISIBILITY callback () : _closure_type (NULL), _closure_void (NULL)
+  {}
   void set_gdb_info (const char *typ, const void *v)
     { _closure_type = typ; _closure_void = v; }
 };
@@ -2502,14 +2546,15 @@ class callback_2_0
   typedef R (*cb_t) (B1, B2);
   cb_t f;
 public:
-  callback_2_0 (callback_line_param cb_t ff)
+  SFS_INLINE_VISIBILITY callback_2_0 (callback_line_param cb_t ff)
     : callback_line_init (callback<R, B1, B2>) f (ff) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return f (b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_2_0() {}
 };
 
 template<class R, class B1, class B2>
-static inline refcounted<callback_2_0<R, B1, B2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_2_0<R, B1, B2> > *
 wrap (wrap_line_param R (*f) (B1, B2))
 {
   return wNew (refcounted<callback_2_0<R, B1, B2> >) (wrap_line_arg f);
@@ -2538,10 +2583,11 @@ public:
     }
 #else /* !WRAP_USE_NODELETE */
 public:
-  callback_c_2_0 (callback_line_param const P &cc, cb_t ff)
+  SFS_INLINE_VISIBILITY callback_c_2_0 (callback_line_param const P &cc, cb_t ff)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_0 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -2568,60 +2614,61 @@ public:
     }
 #else /* !WRAP_USE_NODELETE */
 public:
-  callback_c_2_0_const (callback_line_param const P &cc, cb_t ff)
+  SFS_INLINE_VISIBILITY callback_c_2_0_const (callback_line_param const P &cc, cb_t ff)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_0_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2>
-static inline refcounted<callback_c_2_0< C *, C, R, B1, B2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_0< C *, C, R, B1, B2> > *
 wrap (wrap_line_param  C *p, R (C::*f) (B1, B2) )
 {
   return wNew (refcounted<callback_c_2_0< C *, C, R, B1, B2> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R, class B1, class B2>
-static inline refcounted<callback_c_2_0<ref< C>,  C, R, B1, B2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_0<ref< C>,  C, R, B1, B2> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (B1, B2) )
 {
   return wNew (refcounted<callback_c_2_0<ref< C>,  C, R, B1, B2> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1, class B2>
-static inline refcounted<callback_c_2_0<ref< C>,  C, R, B1, B2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_0<ref< C>,  C, R, B1, B2> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (B1, B2) )
 {
   return wNew (refcounted<callback_c_2_0<ref< C>,  C, R, B1, B2> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1, class B2>
-static inline refcounted<callback_c_2_0<ref< C>,  C, R, B1, B2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_0<ref< C>,  C, R, B1, B2> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (B1, B2) )
 {
   return wNew (refcounted<callback_c_2_0<ref< C>,  C, R, B1, B2> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R, class B1, class B2>
-static inline refcounted<callback_c_2_0_const<const C *, C, R, B1, B2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_0_const<const C *, C, R, B1, B2> > *
 wrap (wrap_line_param const C *p, R (C::*f) (B1, B2) const)
 {
   return wNew (refcounted<callback_c_2_0_const<const C *, C, R, B1, B2> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R, class B1, class B2>
-static inline refcounted<callback_c_2_0_const<ref<const C>, const C, R, B1, B2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_0_const<ref<const C>, const C, R, B1, B2> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (B1, B2) const)
 {
   return wNew (refcounted<callback_c_2_0_const<ref<const C>, const C, R, B1, B2> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1, class B2>
-static inline refcounted<callback_c_2_0_const<ref<const C>, const C, R, B1, B2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_0_const<ref<const C>, const C, R, B1, B2> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (B1, B2) const)
 {
   return wNew (refcounted<callback_c_2_0_const<ref<const C>, const C, R, B1, B2> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1, class B2>
-static inline refcounted<callback_c_2_0_const<ref<const C>, const C, R, B1, B2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_0_const<ref<const C>, const C, R, B1, B2> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (B1, B2) const)
 {
   return wNew (refcounted<callback_c_2_0_const<ref<const C>, const C, R, B1, B2> >) (wrap_c_line_arg p, f);
@@ -2634,14 +2681,15 @@ class callback_2_1
   cb_t f;
   A1 a1;
 public:
-  callback_2_1 (callback_line_param cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_2_1 (callback_line_param cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R, B1, B2>) f (ff), a1 (aa1) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return f (a1, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_2_1() {}
 };
 
 template<class R, class B1, class B2, class A1, class AA1>
-static inline refcounted<callback_2_1<R, B1, B2, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_2_1<R, B1, B2, A1> > *
 wrap (wrap_line_param R (*f) (A1, B1, B2), const AA1 &a1)
 {
   return wNew (refcounted<callback_2_1<R, B1, B2, A1> >) (wrap_line_arg f, a1);
@@ -2672,10 +2720,11 @@ public:
 #else /* !WRAP_USE_NODELETE */
   A1 a1;
 public:
-  callback_c_2_1 (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_c_2_1 (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff), a1 (aa1) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (a1, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_1 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -2704,60 +2753,61 @@ public:
 #else /* !WRAP_USE_NODELETE */
   A1 a1;
 public:
-  callback_c_2_1_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_c_2_1_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff), a1 (aa1) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (a1, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_1_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class A1, class AA1>
-static inline refcounted<callback_c_2_1< C *, C, R, B1, B2, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_1< C *, C, R, B1, B2, A1> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, B1, B2) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_2_1< C *, C, R, B1, B2, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1>
-static inline refcounted<callback_c_2_1<ref< C>,  C, R, B1, B2, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_1<ref< C>,  C, R, B1, B2, A1> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, B1, B2) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_2_1<ref< C>,  C, R, B1, B2, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1>
-static inline refcounted<callback_c_2_1<ref< C>,  C, R, B1, B2, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_1<ref< C>,  C, R, B1, B2, A1> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, B1, B2) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_2_1<ref< C>,  C, R, B1, B2, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1>
-static inline refcounted<callback_c_2_1<ref< C>,  C, R, B1, B2, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_1<ref< C>,  C, R, B1, B2, A1> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, B1, B2) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_2_1<ref< C>,  C, R, B1, B2, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1>
-static inline refcounted<callback_c_2_1_const<const C *, C, R, B1, B2, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_1_const<const C *, C, R, B1, B2, A1> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, B1, B2) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_2_1_const<const C *, C, R, B1, B2, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1>
-static inline refcounted<callback_c_2_1_const<ref<const C>, const C, R, B1, B2, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_1_const<ref<const C>, const C, R, B1, B2, A1> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, B1, B2) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_2_1_const<ref<const C>, const C, R, B1, B2, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1>
-static inline refcounted<callback_c_2_1_const<ref<const C>, const C, R, B1, B2, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_1_const<ref<const C>, const C, R, B1, B2, A1> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, B1, B2) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_2_1_const<ref<const C>, const C, R, B1, B2, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1>
-static inline refcounted<callback_c_2_1_const<ref<const C>, const C, R, B1, B2, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_1_const<ref<const C>, const C, R, B1, B2, A1> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, B1, B2) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_2_1_const<ref<const C>, const C, R, B1, B2, A1> >) (wrap_c_line_arg p, f, a1);
@@ -2771,14 +2821,15 @@ class callback_2_2
   A1 a1;
   A2 a2;
 public:
-  callback_2_2 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_2_2 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R, B1, B2>) f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return f (a1, a2, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_2_2() {}
 };
 
 template<class R, class B1, class B2, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_2_2<R, B1, B2, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_2_2<R, B1, B2, A1, A2> > *
 wrap (wrap_line_param R (*f) (A1, A2, B1, B2), const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_2_2<R, B1, B2, A1, A2> >) (wrap_line_arg f, a1, a2);
@@ -2811,10 +2862,11 @@ public:
   A1 a1;
   A2 a2;
 public:
-  callback_c_2_2 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_c_2_2 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (a1, a2, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_2 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -2845,60 +2897,61 @@ public:
   A1 a1;
   A2 a2;
 public:
-  callback_c_2_2_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_c_2_2_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (a1, a2, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_2_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_2_2< C *, C, R, B1, B2, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_2< C *, C, R, B1, B2, A1, A2> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, B1, B2) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_2_2< C *, C, R, B1, B2, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_2_2<ref< C>,  C, R, B1, B2, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_2<ref< C>,  C, R, B1, B2, A1, A2> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, B1, B2) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_2_2<ref< C>,  C, R, B1, B2, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_2_2<ref< C>,  C, R, B1, B2, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_2<ref< C>,  C, R, B1, B2, A1, A2> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, B1, B2) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_2_2<ref< C>,  C, R, B1, B2, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_2_2<ref< C>,  C, R, B1, B2, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_2<ref< C>,  C, R, B1, B2, A1, A2> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, B1, B2) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_2_2<ref< C>,  C, R, B1, B2, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_2_2_const<const C *, C, R, B1, B2, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_2_const<const C *, C, R, B1, B2, A1, A2> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, B1, B2) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_2_2_const<const C *, C, R, B1, B2, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_2_2_const<ref<const C>, const C, R, B1, B2, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_2_const<ref<const C>, const C, R, B1, B2, A1, A2> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, B1, B2) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_2_2_const<ref<const C>, const C, R, B1, B2, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_2_2_const<ref<const C>, const C, R, B1, B2, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_2_const<ref<const C>, const C, R, B1, B2, A1, A2> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, B1, B2) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_2_2_const<ref<const C>, const C, R, B1, B2, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_2_2_const<ref<const C>, const C, R, B1, B2, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_2_const<ref<const C>, const C, R, B1, B2, A1, A2> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, B1, B2) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_2_2_const<ref<const C>, const C, R, B1, B2, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
@@ -2913,14 +2966,15 @@ class callback_2_3
   A2 a2;
   A3 a3;
 public:
-  callback_2_3 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_2_3 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R, B1, B2>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return f (a1, a2, a3, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_2_3() {}
 };
 
 template<class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_2_3<R, B1, B2, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_2_3<R, B1, B2, A1, A2, A3> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, B1, B2), const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_2_3<R, B1, B2, A1, A2, A3> >) (wrap_line_arg f, a1, a2, a3);
@@ -2955,10 +3009,11 @@ public:
   A2 a2;
   A3 a3;
 public:
-  callback_c_2_3 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_c_2_3 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (a1, a2, a3, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_3 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -2991,60 +3046,61 @@ public:
   A2 a2;
   A3 a3;
 public:
-  callback_c_2_3_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_c_2_3_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (a1, a2, a3, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_3_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_2_3< C *, C, R, B1, B2, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_3< C *, C, R, B1, B2, A1, A2, A3> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_2_3< C *, C, R, B1, B2, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_2_3<ref< C>,  C, R, B1, B2, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_3<ref< C>,  C, R, B1, B2, A1, A2, A3> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_2_3<ref< C>,  C, R, B1, B2, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_2_3<ref< C>,  C, R, B1, B2, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_3<ref< C>,  C, R, B1, B2, A1, A2, A3> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_2_3<ref< C>,  C, R, B1, B2, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_2_3<ref< C>,  C, R, B1, B2, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_3<ref< C>,  C, R, B1, B2, A1, A2, A3> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_2_3<ref< C>,  C, R, B1, B2, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_2_3_const<const C *, C, R, B1, B2, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_3_const<const C *, C, R, B1, B2, A1, A2, A3> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_2_3_const<const C *, C, R, B1, B2, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_2_3_const<ref<const C>, const C, R, B1, B2, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_3_const<ref<const C>, const C, R, B1, B2, A1, A2, A3> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_2_3_const<ref<const C>, const C, R, B1, B2, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_2_3_const<ref<const C>, const C, R, B1, B2, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_3_const<ref<const C>, const C, R, B1, B2, A1, A2, A3> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_2_3_const<ref<const C>, const C, R, B1, B2, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_2_3_const<ref<const C>, const C, R, B1, B2, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_3_const<ref<const C>, const C, R, B1, B2, A1, A2, A3> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_2_3_const<ref<const C>, const C, R, B1, B2, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
@@ -3061,14 +3117,15 @@ class callback_2_4
   A3 a3;
   A4 a4;
 public:
-  callback_2_4 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_2_4 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R, B1, B2>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return f (a1, a2, a3, a4, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_2_4() {}
 };
 
 template<class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_2_4<R, B1, B2, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_2_4<R, B1, B2, A1, A2, A3, A4> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, A4, B1, B2), const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_2_4<R, B1, B2, A1, A2, A3, A4> >) (wrap_line_arg f, a1, a2, a3, a4);
@@ -3105,10 +3162,11 @@ public:
   A3 a3;
   A4 a4;
 public:
-  callback_c_2_4 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_c_2_4 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (a1, a2, a3, a4, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_4 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -3143,60 +3201,61 @@ public:
   A3 a3;
   A4 a4;
 public:
-  callback_c_2_4_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_c_2_4_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (a1, a2, a3, a4, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_4_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_2_4< C *, C, R, B1, B2, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_4< C *, C, R, B1, B2, A1, A2, A3, A4> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, A4, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_2_4< C *, C, R, B1, B2, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_2_4<ref< C>,  C, R, B1, B2, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_4<ref< C>,  C, R, B1, B2, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, A4, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_2_4<ref< C>,  C, R, B1, B2, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_2_4<ref< C>,  C, R, B1, B2, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_4<ref< C>,  C, R, B1, B2, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, A4, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_2_4<ref< C>,  C, R, B1, B2, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_2_4<ref< C>,  C, R, B1, B2, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_4<ref< C>,  C, R, B1, B2, A1, A2, A3, A4> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, A4, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_2_4<ref< C>,  C, R, B1, B2, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_2_4_const<const C *, C, R, B1, B2, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_4_const<const C *, C, R, B1, B2, A1, A2, A3, A4> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, A4, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_2_4_const<const C *, C, R, B1, B2, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_2_4_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_4_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, A4, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_2_4_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_2_4_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_4_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, A4, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_2_4_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_2_4_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_4_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, A4, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_2_4_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
@@ -3216,14 +3275,15 @@ class callback_2_5
   A4 a4;
   A5 a5;
 public:
-  callback_2_5 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_2_5 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R, B1, B2>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return f (a1, a2, a3, a4, a5, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_2_5() {}
 };
 
 template<class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_2_5<R, B1, B2, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_2_5<R, B1, B2, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, A4, A5, B1, B2), const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_2_5<R, B1, B2, A1, A2, A3, A4, A5> >) (wrap_line_arg f, a1, a2, a3, a4, a5);
@@ -3262,10 +3322,11 @@ public:
   A4 a4;
   A5 a5;
 public:
-  callback_c_2_5 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_c_2_5 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (a1, a2, a3, a4, a5, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_5 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -3302,60 +3363,61 @@ public:
   A4 a4;
   A5 a5;
 public:
-  callback_c_2_5_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_c_2_5_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R, B1, B2>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() (B1 b1, B2 b2)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2)
     { return ((*c).*f) (a1, a2, a3, a4, a5, b1, b2); }
+  SFS_INLINE_VISIBILITY ~callback_c_2_5_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_2_5< C *, C, R, B1, B2, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_5< C *, C, R, B1, B2, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_2_5< C *, C, R, B1, B2, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_2_5<ref< C>,  C, R, B1, B2, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_5<ref< C>,  C, R, B1, B2, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_2_5<ref< C>,  C, R, B1, B2, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_2_5<ref< C>,  C, R, B1, B2, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_5<ref< C>,  C, R, B1, B2, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_2_5<ref< C>,  C, R, B1, B2, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_2_5<ref< C>,  C, R, B1, B2, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_5<ref< C>,  C, R, B1, B2, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_2_5<ref< C>,  C, R, B1, B2, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_2_5_const<const C *, C, R, B1, B2, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_5_const<const C *, C, R, B1, B2, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_2_5_const<const C *, C, R, B1, B2, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_2_5_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_5_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_2_5_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_2_5_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_5_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_2_5_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class B2, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_2_5_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_2_5_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_2_5_const<ref<const C>, const C, R, B1, B2, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
@@ -3380,11 +3442,10 @@ public:
     : dest (df[0] == '&' ? df + 1 : df), src (f), line (l) {}
 #endif /* WRAP_DEBUG */
   virtual R operator() (B1 b1, B2 b2, B3 b3) = 0;
-  virtual void trigger (B1 b1, B2 b2, B3 b3) { 
-      (void) (*this) (b1, b2, b3); 
-  }
-  virtual ~callback () {}
-  callback () : _closure_type (NULL), _closure_void (NULL) {}
+  virtual SFS_INLINE_VISIBILITY void trigger (B1 b1, B2 b2, B3 b3) { (void) (*this) (b1, b2, b3); }
+  virtual SFS_INLINE_VISIBILITY ~callback () {}
+  SFS_INLINE_VISIBILITY callback () : _closure_type (NULL), _closure_void (NULL)
+  {}
   void set_gdb_info (const char *typ, const void *v)
     { _closure_type = typ; _closure_void = v; }
 };
@@ -3396,14 +3457,15 @@ class callback_3_0
   typedef R (*cb_t) (B1, B2, B3);
   cb_t f;
 public:
-  callback_3_0 (callback_line_param cb_t ff)
+  SFS_INLINE_VISIBILITY callback_3_0 (callback_line_param cb_t ff)
     : callback_line_init (callback<R, B1, B2, B3>) f (ff) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return f (b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_3_0() {}
 };
 
 template<class R, class B1, class B2, class B3>
-static inline refcounted<callback_3_0<R, B1, B2, B3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_3_0<R, B1, B2, B3> > *
 wrap (wrap_line_param R (*f) (B1, B2, B3))
 {
   return wNew (refcounted<callback_3_0<R, B1, B2, B3> >) (wrap_line_arg f);
@@ -3432,10 +3494,11 @@ public:
     }
 #else /* !WRAP_USE_NODELETE */
 public:
-  callback_c_3_0 (callback_line_param const P &cc, cb_t ff)
+  SFS_INLINE_VISIBILITY callback_c_3_0 (callback_line_param const P &cc, cb_t ff)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_0 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -3462,60 +3525,61 @@ public:
     }
 #else /* !WRAP_USE_NODELETE */
 public:
-  callback_c_3_0_const (callback_line_param const P &cc, cb_t ff)
+  SFS_INLINE_VISIBILITY callback_c_3_0_const (callback_line_param const P &cc, cb_t ff)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_0_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class B3>
-static inline refcounted<callback_c_3_0< C *, C, R, B1, B2, B3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_0< C *, C, R, B1, B2, B3> > *
 wrap (wrap_line_param  C *p, R (C::*f) (B1, B2, B3) )
 {
   return wNew (refcounted<callback_c_3_0< C *, C, R, B1, B2, B3> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R, class B1, class B2, class B3>
-static inline refcounted<callback_c_3_0<ref< C>,  C, R, B1, B2, B3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_0<ref< C>,  C, R, B1, B2, B3> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (B1, B2, B3) )
 {
   return wNew (refcounted<callback_c_3_0<ref< C>,  C, R, B1, B2, B3> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1, class B2, class B3>
-static inline refcounted<callback_c_3_0<ref< C>,  C, R, B1, B2, B3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_0<ref< C>,  C, R, B1, B2, B3> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (B1, B2, B3) )
 {
   return wNew (refcounted<callback_c_3_0<ref< C>,  C, R, B1, B2, B3> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1, class B2, class B3>
-static inline refcounted<callback_c_3_0<ref< C>,  C, R, B1, B2, B3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_0<ref< C>,  C, R, B1, B2, B3> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (B1, B2, B3) )
 {
   return wNew (refcounted<callback_c_3_0<ref< C>,  C, R, B1, B2, B3> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R, class B1, class B2, class B3>
-static inline refcounted<callback_c_3_0_const<const C *, C, R, B1, B2, B3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_0_const<const C *, C, R, B1, B2, B3> > *
 wrap (wrap_line_param const C *p, R (C::*f) (B1, B2, B3) const)
 {
   return wNew (refcounted<callback_c_3_0_const<const C *, C, R, B1, B2, B3> >) (wrap_c_line_arg p, f);
 }
 
 template<class C, class R, class B1, class B2, class B3>
-static inline refcounted<callback_c_3_0_const<ref<const C>, const C, R, B1, B2, B3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_0_const<ref<const C>, const C, R, B1, B2, B3> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (B1, B2, B3) const)
 {
   return wNew (refcounted<callback_c_3_0_const<ref<const C>, const C, R, B1, B2, B3> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1, class B2, class B3>
-static inline refcounted<callback_c_3_0_const<ref<const C>, const C, R, B1, B2, B3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_0_const<ref<const C>, const C, R, B1, B2, B3> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (B1, B2, B3) const)
 {
   return wNew (refcounted<callback_c_3_0_const<ref<const C>, const C, R, B1, B2, B3> >) (wrap_c_line_arg p, f);
 }
 template<class C, class R, class B1, class B2, class B3>
-static inline refcounted<callback_c_3_0_const<ref<const C>, const C, R, B1, B2, B3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_0_const<ref<const C>, const C, R, B1, B2, B3> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (B1, B2, B3) const)
 {
   return wNew (refcounted<callback_c_3_0_const<ref<const C>, const C, R, B1, B2, B3> >) (wrap_c_line_arg p, f);
@@ -3528,14 +3592,15 @@ class callback_3_1
   cb_t f;
   A1 a1;
 public:
-  callback_3_1 (callback_line_param cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_3_1 (callback_line_param cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R, B1, B2, B3>) f (ff), a1 (aa1) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return f (a1, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_3_1() {}
 };
 
 template<class R, class B1, class B2, class B3, class A1, class AA1>
-static inline refcounted<callback_3_1<R, B1, B2, B3, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_3_1<R, B1, B2, B3, A1> > *
 wrap (wrap_line_param R (*f) (A1, B1, B2, B3), const AA1 &a1)
 {
   return wNew (refcounted<callback_3_1<R, B1, B2, B3, A1> >) (wrap_line_arg f, a1);
@@ -3566,10 +3631,11 @@ public:
 #else /* !WRAP_USE_NODELETE */
   A1 a1;
 public:
-  callback_c_3_1 (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_c_3_1 (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff), a1 (aa1) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (a1, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_1 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -3598,60 +3664,61 @@ public:
 #else /* !WRAP_USE_NODELETE */
   A1 a1;
 public:
-  callback_c_3_1_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
+  SFS_INLINE_VISIBILITY callback_c_3_1_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff), a1 (aa1) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (a1, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_1_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1>
-static inline refcounted<callback_c_3_1< C *, C, R, B1, B2, B3, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_1< C *, C, R, B1, B2, B3, A1> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, B1, B2, B3) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_3_1< C *, C, R, B1, B2, B3, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1>
-static inline refcounted<callback_c_3_1<ref< C>,  C, R, B1, B2, B3, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_1<ref< C>,  C, R, B1, B2, B3, A1> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, B1, B2, B3) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_3_1<ref< C>,  C, R, B1, B2, B3, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1>
-static inline refcounted<callback_c_3_1<ref< C>,  C, R, B1, B2, B3, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_1<ref< C>,  C, R, B1, B2, B3, A1> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, B1, B2, B3) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_3_1<ref< C>,  C, R, B1, B2, B3, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1>
-static inline refcounted<callback_c_3_1<ref< C>,  C, R, B1, B2, B3, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_1<ref< C>,  C, R, B1, B2, B3, A1> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, B1, B2, B3) , const AA1 &a1)
 {
   return wNew (refcounted<callback_c_3_1<ref< C>,  C, R, B1, B2, B3, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1>
-static inline refcounted<callback_c_3_1_const<const C *, C, R, B1, B2, B3, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_1_const<const C *, C, R, B1, B2, B3, A1> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, B1, B2, B3) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_3_1_const<const C *, C, R, B1, B2, B3, A1> >) (wrap_c_line_arg p, f, a1);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1>
-static inline refcounted<callback_c_3_1_const<ref<const C>, const C, R, B1, B2, B3, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_1_const<ref<const C>, const C, R, B1, B2, B3, A1> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, B1, B2, B3) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_3_1_const<ref<const C>, const C, R, B1, B2, B3, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1>
-static inline refcounted<callback_c_3_1_const<ref<const C>, const C, R, B1, B2, B3, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_1_const<ref<const C>, const C, R, B1, B2, B3, A1> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, B1, B2, B3) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_3_1_const<ref<const C>, const C, R, B1, B2, B3, A1> >) (wrap_c_line_arg p, f, a1);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1>
-static inline refcounted<callback_c_3_1_const<ref<const C>, const C, R, B1, B2, B3, A1> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_1_const<ref<const C>, const C, R, B1, B2, B3, A1> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, B1, B2, B3) const, const AA1 &a1)
 {
   return wNew (refcounted<callback_c_3_1_const<ref<const C>, const C, R, B1, B2, B3, A1> >) (wrap_c_line_arg p, f, a1);
@@ -3665,14 +3732,15 @@ class callback_3_2
   A1 a1;
   A2 a2;
 public:
-  callback_3_2 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_3_2 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R, B1, B2, B3>) f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return f (a1, a2, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_3_2() {}
 };
 
 template<class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_3_2<R, B1, B2, B3, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_3_2<R, B1, B2, B3, A1, A2> > *
 wrap (wrap_line_param R (*f) (A1, A2, B1, B2, B3), const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_3_2<R, B1, B2, B3, A1, A2> >) (wrap_line_arg f, a1, a2);
@@ -3705,10 +3773,11 @@ public:
   A1 a1;
   A2 a2;
 public:
-  callback_c_3_2 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_c_3_2 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (a1, a2, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_2 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -3739,60 +3808,61 @@ public:
   A1 a1;
   A2 a2;
 public:
-  callback_c_3_2_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
+  SFS_INLINE_VISIBILITY callback_c_3_2_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff), a1 (aa1), a2 (aa2) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (a1, a2, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_2_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_3_2< C *, C, R, B1, B2, B3, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_2< C *, C, R, B1, B2, B3, A1, A2> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, B1, B2, B3) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_3_2< C *, C, R, B1, B2, B3, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_3_2<ref< C>,  C, R, B1, B2, B3, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_2<ref< C>,  C, R, B1, B2, B3, A1, A2> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, B1, B2, B3) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_3_2<ref< C>,  C, R, B1, B2, B3, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_3_2<ref< C>,  C, R, B1, B2, B3, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_2<ref< C>,  C, R, B1, B2, B3, A1, A2> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, B1, B2, B3) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_3_2<ref< C>,  C, R, B1, B2, B3, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_3_2<ref< C>,  C, R, B1, B2, B3, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_2<ref< C>,  C, R, B1, B2, B3, A1, A2> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, B1, B2, B3) , const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_3_2<ref< C>,  C, R, B1, B2, B3, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_3_2_const<const C *, C, R, B1, B2, B3, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_2_const<const C *, C, R, B1, B2, B3, A1, A2> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, B1, B2, B3) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_3_2_const<const C *, C, R, B1, B2, B3, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_3_2_const<ref<const C>, const C, R, B1, B2, B3, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_2_const<ref<const C>, const C, R, B1, B2, B3, A1, A2> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, B1, B2, B3) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_3_2_const<ref<const C>, const C, R, B1, B2, B3, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_3_2_const<ref<const C>, const C, R, B1, B2, B3, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_2_const<ref<const C>, const C, R, B1, B2, B3, A1, A2> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, B1, B2, B3) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_3_2_const<ref<const C>, const C, R, B1, B2, B3, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2>
-static inline refcounted<callback_c_3_2_const<ref<const C>, const C, R, B1, B2, B3, A1, A2> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_2_const<ref<const C>, const C, R, B1, B2, B3, A1, A2> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, B1, B2, B3) const, const AA1 &a1, const AA2 &a2)
 {
   return wNew (refcounted<callback_c_3_2_const<ref<const C>, const C, R, B1, B2, B3, A1, A2> >) (wrap_c_line_arg p, f, a1, a2);
@@ -3807,14 +3877,15 @@ class callback_3_3
   A2 a2;
   A3 a3;
 public:
-  callback_3_3 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_3_3 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R, B1, B2, B3>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return f (a1, a2, a3, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_3_3() {}
 };
 
 template<class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_3_3<R, B1, B2, B3, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_3_3<R, B1, B2, B3, A1, A2, A3> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, B1, B2, B3), const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_3_3<R, B1, B2, B3, A1, A2, A3> >) (wrap_line_arg f, a1, a2, a3);
@@ -3849,10 +3920,11 @@ public:
   A2 a2;
   A3 a3;
 public:
-  callback_c_3_3 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_c_3_3 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (a1, a2, a3, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_3 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -3885,60 +3957,61 @@ public:
   A2 a2;
   A3 a3;
 public:
-  callback_c_3_3_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
+  SFS_INLINE_VISIBILITY callback_c_3_3_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (a1, a2, a3, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_3_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_3_3< C *, C, R, B1, B2, B3, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_3< C *, C, R, B1, B2, B3, A1, A2, A3> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_3_3< C *, C, R, B1, B2, B3, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_3_3<ref< C>,  C, R, B1, B2, B3, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_3<ref< C>,  C, R, B1, B2, B3, A1, A2, A3> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_3_3<ref< C>,  C, R, B1, B2, B3, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_3_3<ref< C>,  C, R, B1, B2, B3, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_3<ref< C>,  C, R, B1, B2, B3, A1, A2, A3> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_3_3<ref< C>,  C, R, B1, B2, B3, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_3_3<ref< C>,  C, R, B1, B2, B3, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_3<ref< C>,  C, R, B1, B2, B3, A1, A2, A3> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_3_3<ref< C>,  C, R, B1, B2, B3, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_3_3_const<const C *, C, R, B1, B2, B3, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_3_const<const C *, C, R, B1, B2, B3, A1, A2, A3> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_3_3_const<const C *, C, R, B1, B2, B3, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_3_3_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_3_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_3_3_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_3_3_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_3_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_3_3_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3>
-static inline refcounted<callback_c_3_3_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_3_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3)
 {
   return wNew (refcounted<callback_c_3_3_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3> >) (wrap_c_line_arg p, f, a1, a2, a3);
@@ -3955,14 +4028,15 @@ class callback_3_4
   A3 a3;
   A4 a4;
 public:
-  callback_3_4 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_3_4 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R, B1, B2, B3>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return f (a1, a2, a3, a4, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_3_4() {}
 };
 
 template<class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_3_4<R, B1, B2, B3, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_3_4<R, B1, B2, B3, A1, A2, A3, A4> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, A4, B1, B2, B3), const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_3_4<R, B1, B2, B3, A1, A2, A3, A4> >) (wrap_line_arg f, a1, a2, a3, a4);
@@ -3999,10 +4073,11 @@ public:
   A3 a3;
   A4 a4;
 public:
-  callback_c_3_4 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_c_3_4 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (a1, a2, a3, a4, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_4 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -4037,60 +4112,61 @@ public:
   A3 a3;
   A4 a4;
 public:
-  callback_c_3_4_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
+  SFS_INLINE_VISIBILITY callback_c_3_4_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (a1, a2, a3, a4, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_4_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_3_4< C *, C, R, B1, B2, B3, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_4< C *, C, R, B1, B2, B3, A1, A2, A3, A4> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, A4, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_3_4< C *, C, R, B1, B2, B3, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_3_4<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_4<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, A4, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_3_4<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_3_4<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_4<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, A4, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_3_4<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_3_4<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_4<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, A4, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_3_4<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_3_4_const<const C *, C, R, B1, B2, B3, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_4_const<const C *, C, R, B1, B2, B3, A1, A2, A3, A4> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, A4, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_3_4_const<const C *, C, R, B1, B2, B3, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_3_4_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_4_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, A4, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_3_4_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_3_4_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_4_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, A4, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_3_4_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4>
-static inline refcounted<callback_c_3_4_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_4_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, A4, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4)
 {
   return wNew (refcounted<callback_c_3_4_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4> >) (wrap_c_line_arg p, f, a1, a2, a3, a4);
@@ -4110,14 +4186,15 @@ class callback_3_5
   A4 a4;
   A5 a5;
 public:
-  callback_3_5 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_3_5 (callback_line_param cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R, B1, B2, B3>) f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return f (a1, a2, a3, a4, a5, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_3_5() {}
 };
 
 template<class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_3_5<R, B1, B2, B3, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_3_5<R, B1, B2, B3, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param R (*f) (A1, A2, A3, A4, A5, B1, B2, B3), const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_3_5<R, B1, B2, B3, A1, A2, A3, A4, A5> >) (wrap_line_arg f, a1, a2, a3, a4, a5);
@@ -4156,10 +4233,11 @@ public:
   A4 a4;
   A5 a5;
 public:
-  callback_c_3_5 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_c_3_5 (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (a1, a2, a3, a4, a5, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_5 () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
@@ -4196,60 +4274,61 @@ public:
   A4 a4;
   A5 a5;
 public:
-  callback_c_3_5_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
+  SFS_INLINE_VISIBILITY callback_c_3_5_const (callback_line_param const P &cc, cb_t ff, const A1 &aa1, const A2 &aa2, const A3 &aa3, const A4 &aa4, const A5 &aa5)
     : callback_line_init (callback<R, B1, B2, B3>) c (cc), f (ff), a1 (aa1), a2 (aa2), a3 (aa3), a4 (aa4), a5 (aa5) {}
-  R operator() (B1 b1, B2 b2, B3 b3)
+  SFS_INLINE_VISIBILITY R operator() (B1 b1, B2 b2, B3 b3)
     { return ((*c).*f) (a1, a2, a3, a4, a5, b1, b2, b3); }
+  SFS_INLINE_VISIBILITY ~callback_c_3_5_const () {}
 #endif /* !WRAP_USE_NODELETE */
 };
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_3_5< C *, C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_5< C *, C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param  C *p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_3_5< C *, C, R, B1, B2, B3, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_3_5<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_5<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ref< C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_3_5<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_3_5<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_5<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ptr< C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_3_5<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_3_5<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_5<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const refcounted< C> *p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2, B3) , const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_3_5<ref< C>,  C, R, B1, B2, B3, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_3_5_const<const C *, C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_5_const<const C *, C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const C *p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_3_5_const<const C *, C, R, B1, B2, B3, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_3_5_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_5_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ref<const C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_3_5_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_3_5_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_5_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const ptr<const C> &p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_3_5_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);
 }
 template<class C, class R, class B1, class B2, class B3, class A1, class AA1, class A2, class AA2, class A3, class AA3, class A4, class AA4, class A5, class AA5>
-static inline refcounted<callback_c_3_5_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
+static SFS_INLINE_VISIBILITY inline refcounted<callback_c_3_5_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4, A5> > *
 wrap (wrap_line_param const refcounted<const C> *p, R (C::*f) (A1, A2, A3, A4, A5, B1, B2, B3) const, const AA1 &a1, const AA2 &a2, const AA3 &a3, const AA4 &a4, const AA5 &a5)
 {
   return wNew (refcounted<callback_c_3_5_const<ref<const C>, const C, R, B1, B2, B3, A1, A2, A3, A4, A5> >) (wrap_c_line_arg p, f, a1, a2, a3, a4, a5);

--- a/async/err.h
+++ b/async/err.h
@@ -104,14 +104,14 @@ struct traceobj : public strbuf {
 };
 
 template<class T> inline const traceobj &
-operator<< (const traceobj &sb, const T &a)
+SFS_INLINE_VISIBILITY operator<< (const traceobj &sb, const T &a)
 {
   if (sb.doprint)
     strbuf_cat (sb, a);
   return sb;
 }
 inline const traceobj &
-operator<< (const traceobj &sb, const str &s)
+SFS_INLINE_VISIBILITY operator<< (const traceobj &sb, const str &s)
 {
   if (sb.doprint)
     suio_print (sb.tosuio (), s);
@@ -119,14 +119,14 @@ operator<< (const traceobj &sb, const str &s)
 }
 
 template<class T> inline const warnobj &
-operator<< (const warnobj &sb, const T &a)
+SFS_INLINE_VISIBILITY operator<< (const warnobj &sb, const T &a)
 {
   strbuf_cat (sb, a);
   return sb;
 }
 
 inline const warnobj &
-operator<< (const warnobj &sb, const str &s)
+SFS_INLINE_VISIBILITY operator<< (const warnobj &sb, const str &s)
 {
   if (s)
     suio_print (sb.tosuio (), s);

--- a/async/list.h
+++ b/async/list.h
@@ -95,7 +95,7 @@ struct tailq {
   T *first;
   T **plast;
 
-  tailq () {first = NULL; plast = &first;}
+  SFS_INLINE_VISIBILITY tailq () {first = NULL; plast = &first;}
 
   void insert_head (T *elm) {
     if (((elm->*field).next = first))
@@ -122,7 +122,7 @@ struct tailq {
     return elm;
   }
 
-  static T *next (T *elm) {
+  static SFS_INLINE_VISIBILITY T *next (T *elm) {
     return (elm->*field).next;
   }
 

--- a/async/qhash.h
+++ b/async/qhash.h
@@ -50,8 +50,11 @@ template<class K, class V> struct qhash_slot {
   ihash_entry<qhash_slot> link;
   const K key;
   V value;
-  qhash_slot (const K &k, typename CREF (V) v) : key (k), value (v) {}
-  qhash_slot (const K &k, typename NCREF (V) v) : key (k), value (v) {}
+  SFS_INLINE_VISIBILITY qhash_slot (const K &k, typename CREF (V) v) :
+    key (k), value (v) {}
+  SFS_INLINE_VISIBILITY qhash_slot (const K &k, typename NCREF (V) v) :
+    key (k), value (v) {}
+  SFS_INLINE_VISIBILITY ~qhash_slot() = default;
 };
 
 template<class K, class V, class H, class E>
@@ -93,7 +96,9 @@ protected:
     { (*cb) (s->key, R::ret (&s->value)); }
 
 public:
+  SFS_INLINE_VISIBILITY
   qhash () : eq (E ()), hash (H ()) {}
+
   qhash (const qhash<K,V,H,E,R> &in)
   {
     in.core::traverse (wrap (this, &qhash::copyslot));
@@ -101,10 +106,14 @@ public:
   explicit qhash(std::initializer_list<slot> l) {
       for (const auto &v : l) { core::insert_val(New slot(v), hash(v.key)); }
   }
+
+  SFS_INLINE_VISIBILITY
   void clear () {
     core::traverse (wrap (this, &qhash::delslot));
     core::clear ();
   }
+
+  SFS_INLINE_VISIBILITY
   ~qhash () { clear (); }
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
   qhash(qhash<K,V,H,E,R>&& q) = delete;
@@ -142,10 +151,14 @@ public:
     else
       core::insert_val (New slot (k, v), hash (k));
   }
+
+  SFS_INLINE_VISIBILITY
   void remove (const K &k) {
     if (slot *s = getslot (k))
       delslot (s);
   }
+
+  SFS_INLINE_VISIBILITY
   bool lookup(const K &k, typename R::type v) {
       auto _v = (*this)[k];
       if (_v) {
@@ -154,6 +167,8 @@ public:
       }
       return false;
   }
+
+  SFS_INLINE_VISIBILITY
   typename R::type operator[] (const K &k) {
     if (slot *s = getslot (k))
       return R::ret (&s->value);
@@ -161,6 +176,7 @@ public:
       return R::ret (NULL);
   }
 
+  SFS_INLINE_VISIBILITY
   bool remove (const K &k, V *v) {
     if (slot *s = getslot (k)) {
       *v = s->value;
@@ -171,6 +187,7 @@ public:
     }
   }
 
+  SFS_INLINE_VISIBILITY
   typename R::const_type operator[] (const K &k) const {
     if (slot *s = getslot (k))
       return R::const_ret (&s->value);
@@ -178,19 +195,21 @@ public:
       return R::const_ret (NULL);
   }
 
-  qhash_const_iterator_t<K,V,H,E> begin () const { 
+  SFS_INLINE_VISIBILITY qhash_const_iterator_t<K,V,H,E> begin () const { 
     return qhash_const_iterator_t<K,V,H,E>(*this);
   };
-  qhash_iterator_t<K,V,H,E> begin () { 
+
+  SFS_INLINE_VISIBILITY qhash_iterator_t<K,V,H,E> begin () { 
     return qhash_iterator_t<K,V,H,E>(*this);
   };
 
-  qhash_const_iterator_t<K,V,H,E> end () const { 
+  SFS_INLINE_VISIBILITY qhash_const_iterator_t<K,V,H,E> end () const { 
     qhash_const_iterator_t<K,V,H,E> itr(*this);
     itr._i = NULL;
     return itr;
   };
-  qhash_iterator_t<K,V,H,E> end () { 
+
+  SFS_INLINE_VISIBILITY qhash_iterator_t<K,V,H,E> end () { 
     qhash_iterator_t<K,V,H,E> itr(*this);
     itr._i = NULL;
     return itr;
@@ -201,7 +220,8 @@ public:
 template<class K> struct qhash_slot<K, void> {
   ihash_entry<qhash_slot> link;
   const K key;
-  qhash_slot (const K &k) : key (k) {}
+  SFS_INLINE_VISIBILITY qhash_slot (const K &k) : key (k) {}
+  SFS_INLINE_VISIBILITY ~qhash_slot() = default;
 };
 
 template<class K, class H = hashfn<K>, class E = equals<K>,
@@ -235,9 +255,9 @@ protected:
     { (*cb) (s->key); }
 
 public:
-  bhash () {}
-  void clear () { this->deleteall (); }
-  ~bhash () { clear (); }
+  SFS_INLINE_VISIBILITY bhash () {}
+  SFS_INLINE_VISIBILITY void clear () { this->deleteall (); }
+  SFS_INLINE_VISIBILITY ~bhash () { clear (); }
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
   bhash(bhash<K,H,E>&& b) = delete;
 #endif

--- a/async/sfs_attr.h
+++ b/async/sfs_attr.h
@@ -1,0 +1,4 @@
+// -*-c++-*-
+#pragma once
+#define SFS_INLINE_VISIBILITY __attribute__ ((__visibility__("hidden"), __always_inline__))
+#define SFS_HIDDEN __attribute__ ((__visibility__("hidden")))

--- a/async/vec.h
+++ b/async/vec.h
@@ -33,6 +33,7 @@
 #include <utility>
 #include <initializer_list>
 #endif
+#include "sfs_attr.h"
 
 size_t vec_resize_fn (u_int nwanted, u_int nalloc, int objid);
 class vec_resizer_t {
@@ -45,8 +46,8 @@ void set_vec_resizer (vec_resizer_t *v);
 template<class T>
 struct vec_obj_id_t 
 {
-  vec_obj_id_t () {}
-  int operator() (void) const { return 0; }
+  SFS_INLINE_VISIBILITY vec_obj_id_t () {}
+  SFS_INLINE_VISIBILITY int operator() (void) const { return 0; }
 };
 
 template<class T, size_t N> struct vec_base {
@@ -74,9 +75,9 @@ protected:
   elm_t *lastp; 
   elm_t *limp;
 
-  elm_t *def_basep () { return NULL; }
-  elm_t *def_limp () { return NULL; }
-  void bfree (T *t) { xfree (t); }
+  SFS_INLINE_VISIBILITY elm_t *def_basep () { return NULL; }
+  SFS_INLINE_VISIBILITY elm_t *def_limp () { return NULL; }
+  SFS_INLINE_VISIBILITY void bfree (T *t) { xfree (t); }
 
 public:
 #define doswap(x) tmp = x; x = v.x; v.x = tmp
@@ -103,7 +104,7 @@ protected:
 
   vec_obj_id_t<T> _vec_obj_id;
 
-  void move (elm_t *dst) {
+  SFS_INLINE_VISIBILITY void move (elm_t *dst) {
     if (dst == firstp)
       return;
     assert (dst < firstp || dst >= lastp);
@@ -118,21 +119,28 @@ protected:
     lastp = firstp + n_elem;
   }
 
-  static elm_t &construct (elm_t &e)
+  SFS_INLINE_VISIBILITY static elm_t &construct (elm_t &e)
     { return *new (implicit_cast<void *> (&e)) elm_t; }
-  static elm_t &cconstruct (elm_t &e, const elm_t &v)
+  SFS_INLINE_VISIBILITY static elm_t &cconstruct (elm_t &e, const elm_t &v)
     { return *new (implicit_cast<void *> (&e)) elm_t (v); }
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
   template<typename... Params>
-  static elm_t &vconstruct(elm_t& e, Params&&... p) { 
+  SFS_INLINE_VISIBILITY static elm_t &vconstruct(elm_t& e, Params&&... p) { 
       return *new(implicit_cast<void *>(&e)) elm_t(std::forward<Params>(p)...); 
   }
 #endif
 
-  static void destroy (elm_t &e) { e.~elm_t (); }
+  SFS_INLINE_VISIBILITY static void destroy (elm_t &e) { e.~elm_t (); }
 
-  void init () { lastp = firstp = basep = def_basep (); limp = def_limp (); }
-  void del () { while (firstp < lastp) firstp++->~elm_t (); this->bfree (basep); }
+  SFS_INLINE_VISIBILITY void init () {
+    lastp = firstp = basep = def_basep ();
+    limp = def_limp ();
+  }
+
+  SFS_INLINE_VISIBILITY void del () {
+    while (firstp < lastp) firstp++->~elm_t ();
+    this->bfree (basep);
+  }
 
 #define append(v)						\
 do {								\
@@ -152,8 +160,8 @@ do {								\
 #endif /* !CHECK_BOUNDS */
 
 public:
-  vec () { init (); }
-  vec (const vec &v) { init (); append (v); }
+  SFS_INLINE_VISIBILITY vec () { init (); }
+  SFS_INLINE_VISIBILITY vec (const vec &v) { init (); append (v); }
 
   #ifdef __GXX_EXPERIMENTAL_CXX0X__
   explicit vec(std::initializer_list<T> l) : vec() {
@@ -162,9 +170,13 @@ public:
   }
   #endif
 
-  template<size_t NN> vec (const vec<T, NN> &v) { init (); append (v); }
-  ~vec () { del (); }
-  void clear () { del (); init (); }
+  template<size_t NN>
+  SFS_INLINE_VISIBILITY vec (const vec<T, NN> &v) {
+    init ();
+    append (v);
+  }
+  SFS_INLINE_VISIBILITY ~vec () { del (); }
+  SFS_INLINE_VISIBILITY void clear () { del (); init (); }
 
   vec &operator= (const vec &v)
     { if (this != &v) { clear (); append (v); } return *this; }
@@ -201,28 +213,42 @@ public:
     }
   }
 
-  elm_t *base () { return firstp; }
-  const elm_t *base () const { return firstp; }
-  elm_t *lim () { return lastp; }
-  const elm_t *lim () const { return lastp; }
-  elm_t *begin () { return firstp; }
-  const elm_t *begin () const { return firstp; }
-  elm_t *end () { return lastp; }
-  const elm_t *end () const { return lastp; }
+  SFS_INLINE_VISIBILITY elm_t *base () { return firstp; }
+  SFS_INLINE_VISIBILITY const elm_t *base () const { return firstp; }
+  SFS_INLINE_VISIBILITY elm_t *lim () { return lastp; }
+  SFS_INLINE_VISIBILITY const elm_t *lim () const { return lastp; }
+  SFS_INLINE_VISIBILITY elm_t *begin () { return firstp; }
+  SFS_INLINE_VISIBILITY const elm_t *begin () const { return firstp; }
+  SFS_INLINE_VISIBILITY elm_t *end () { return lastp; }
+  SFS_INLINE_VISIBILITY const elm_t *end () const { return lastp; }
 
-  size_t size () const { return lastp - firstp; }
-  bool empty () const { return lastp == firstp; }
+  SFS_INLINE_VISIBILITY size_t size () const { return lastp - firstp; }
+  SFS_INLINE_VISIBILITY bool empty () const { return lastp == firstp; }
 
-  elm_t &front () { zcheck (); return *firstp; }
-  const elm_t &front () const { zcheck (); return *firstp; }
-  elm_t &back () { zcheck (); return lastp[-1]; }
-  const elm_t &back () const { zcheck (); return lastp[-1]; }
+  SFS_INLINE_VISIBILITY elm_t &front () { zcheck (); return *firstp; }
+  SFS_INLINE_VISIBILITY const elm_t &front () const { zcheck ();
+    return *firstp;
+  }
+  SFS_INLINE_VISIBILITY elm_t &back () { zcheck (); return lastp[-1]; }
+  SFS_INLINE_VISIBILITY const elm_t &back () const {
+    zcheck ();
+    return lastp[-1];
+  }
   
-  elm_t &operator[] (ptrdiff_t i) { bcheck (i); return firstp[i]; }
-  const elm_t &operator[] (ptrdiff_t i) const { bcheck (i); return firstp[i]; }
+  SFS_INLINE_VISIBILITY elm_t &operator[] (ptrdiff_t i) {
+    bcheck (i);
+    return firstp[i];
+  }
+  SFS_INLINE_VISIBILITY const elm_t &operator[] (ptrdiff_t i) const {
+    bcheck (i);
+    return firstp[i];
+  }
 
-  elm_t &push_back () { reserve (1); return construct (*lastp++); }
-  elm_t &push_back (const elm_t &e)
+  SFS_INLINE_VISIBILITY elm_t &push_back () {
+    reserve (1);
+    return construct (*lastp++);
+  }
+  SFS_INLINE_VISIBILITY elm_t &push_back (const elm_t &e)
     { reserve (1); return cconstruct (*lastp++, e); }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__

--- a/libtame/mkevent.pl
+++ b/libtame/mkevent.pl
@@ -67,7 +67,7 @@ sub do_trigger_funcs ($)
     my ($t) = @_;
 
 
-    print("  void trigger (",
+    print("  SFS_HIDDEN void trigger (",
 	   arglist (["const T% &t%", $t]), ")\n",
 	   "  {\n",
 	   "    if (can_trigger ()) {\n",
@@ -86,7 +86,7 @@ sub do_trigger_funcs ($)
 	   "    }\n",
 	   "  }\n");
 
-    print("  void operator() (",
+    print("    SFS_INLINE_VISIBILITY void operator() (",
 	   arglist (["T% t%", $t]), ")",
 	   " { trigger (", arglist(["t%", $t]), "); }\n");
 }
@@ -108,7 +108,7 @@ sub do_event_class ($)
     my $ctss = "const _tame_slot_set$tlist &";
 
     # print the classname
-    print("class ${CN}", $tlist, " :\n",
+    print("class SFS_HIDDEN ${CN}", $tlist, " :\n",
           "     public ${BASE},\n",
           "     public callback${vlist}\n",
           "{\n",
@@ -120,7 +120,7 @@ sub do_event_class ($)
     }
 
     # print the constructors
-    print("  ${CN} (const _tame_slot_set$tlist &rs, const char *loc)\n",
+    print("   SFS_INLINE_VISIBILITY ${CN} (const _tame_slot_set$tlist &rs, const char *loc)\n",
           "   : ${BASE} (loc),\n",
           "     callback${vlist} (CALLBACK_ARGS(loc))");
     if ($t) {
@@ -129,6 +129,9 @@ sub do_event_class ($)
     }
     print("\n",
           "    {}\n\n");
+
+    print("\n",
+          "SFS_INLINE_VISIBILITY ~${CN}() = default;\n\n");
 
     if ($t) {
         print("  ${ctss}slot_set() const\n",
@@ -201,12 +204,12 @@ sub do_event_impl_class ($$)
 
 
     # print the classname
-    print("class ${CNI}", $tlist2, " :\n",
+    print("class SFS_HIDDEN ${CNI}", $tlist2, " :\n",
 	   "     public ${CN}", $tlist , "\n",
 	   "{\n",
 	   "public:\n");
 
-    print("  ${CNI} (",
+    print("  SFS_INLINE_VISIBILITY ${CNI} (",
 	   arglist ("${typconst}action",
 		    "const _tame_slot_set$tlist &rs",
 		    "const char *loc"),
@@ -215,13 +218,13 @@ sub do_event_impl_class ($$)
 	   "      _action (action) {}\n\n");
 
     # print the destructor
-    print("  ~${CNI} () { if (!this->_cleared) clear_action (); ${del}}\n\n");
+    print("  SFS_INLINE_VISIBILITY ~${CNI} () { if (!this->_cleared) clear_action (); ${del}}\n\n");
 
 
     # print the action functions
-    print("  bool perform_action (${EVCB} *e, const char *loc, bool reuse)\n",
+    print("  SFS_INLINE_VISIBILITY bool perform_action (${EVCB} *e, const char *loc, bool reuse)\n",
 	   "  { return ${cthis}perform (e, loc, reuse); }\n");
-    print("  void clear_action () { ${cthis}clear (this); }\n\n");
+    print("  SFS_INLINE_VISIBILITY void clear_action () { ${cthis}clear (this); }\n\n");
 
     print("private:\n");
     print("  ${typ}_action;\n");
@@ -415,7 +418,8 @@ print <<EOF;
 #include "tame_event.h"
 #include "tame_closure.h"
 #include "tame_rendezvous.h"
-
+#include "sfs_attr.h"
+    
 EOF
 
 for (my $t = 0; $t <= $N_tv; $t++) {

--- a/libtame/tame_closure.h
+++ b/libtame/tame_closure.h
@@ -29,7 +29,7 @@
 #include "tame_event.h"
 #include "tame_run.h"
 #include "tame_weakref.h"
-
+#include "sfs_attr.h"
 
 // All closures are numbered serially so that our accounting does not
 // get confused.
@@ -115,13 +115,13 @@ private:
 typedef ptr<closure_t> closure_ptr_t;
 
 template<class C>
-class closure_action 
+class SFS_HIDDEN closure_action 
 #ifdef TAME_DETEMPLATIZE
   : public tame_action 
 #endif 
 {
 public:
-  closure_action (ptr<C> c) : _closure (c) {}
+  SFS_INLINE_VISIBILITY closure_action (ptr<C> c) : _closure (c) {}
 
   //
   // One would like to assert (!_closure) in the destructor,
@@ -130,7 +130,7 @@ public:
   // _closure field aside from just passing it onto other 
   // closure_actions
   //
-  ~closure_action () {}
+  SFS_INLINE_VISIBILITY ~closure_action () {}
 
   bool perform (_event_cancel_base *event, const char *loc, bool _reuse)
   {
@@ -178,16 +178,16 @@ private:
  * of _mkevent.
  */
 template<class C>
-class closure_wrapper {
+class SFS_HIDDEN closure_wrapper {
 public:
-  closure_wrapper (const ptr<C> &c) : _closure (c) {}
-  const ptr<C> &closure () const { return _closure; }
+  SFS_INLINE_VISIBILITY closure_wrapper (const ptr<C> &c) : _closure (c) {}
+  SFS_INLINE_VISIBILITY const ptr<C> &closure () const { return _closure; }
 private:
   const ptr<C> &_closure;
 };
 
 template<class C, class T1, class T2, class T3>
-typename event<T1,T2,T3>::ptr
+SFS_HIDDEN typename event<T1,T2,T3>::ptr
 _mkevent_implicit_rv (const ptr<C> &c, 
 		      const char *loc,
 		      const _tame_slot_set<T1,T2,T3> &rs)
@@ -207,7 +207,7 @@ _mkevent_implicit_rv (const ptr<C> &c,
   return ret;
 }
 
-template<class T> void use_reference (T &i) {}
+template<class T> SFS_INLINE_VISIBILITY void use_reference (T &i) {}
 
 void start_rendezvous_collection ();
 void collect_rendezvous (weakref<rendezvous_base_t> r);
@@ -220,8 +220,9 @@ extern const char *__cls_type;
 // Make an event in a twait{} block based upon a given result slotset.
 // Useful in some connectors...
 template<class C, class T1, class T2, class T3>
-typename event<T1,T2,T3>::ref
-_mkevent_rs (const closure_wrapper<C> &c, const char *loc, const char *ctn,
+SFS_HIDDEN typename event<T1,T2,T3>::ref
+_mkevent_rs (const closure_wrapper<C> &c, const char *loc,
+                                   const char *ctn,
 	     const _tame_slot_set<T1,T2,T3> &ss)
 {
   typename event<T1,T2,T3>::ref ret = 

--- a/libtame/tame_event.h
+++ b/libtame/tame_event.h
@@ -12,6 +12,7 @@
 #include "list.h"
 #include "tame_slotset.h"
 #include "tame_run.h"
+#include "sfs_attr.h"
 
 // Specify 1 extra argument, that way we can do template specialization
 // elsewhere.  We should never have an instatiated event class with
@@ -21,7 +22,7 @@ class _event;
 
 class _event_cancel_base : public virtual refcount {
 public:
-  _event_cancel_base (const char *loc) :
+  SFS_INLINE_VISIBILITY _event_cancel_base (const char *loc) :
     _loc (loc), 
     _cancelled (false),
     _cleared (false),
@@ -29,7 +30,7 @@ public:
     _performing (false)
   { g_stats->did_mkevent (); }
 
-  ~_event_cancel_base () {}
+  SFS_INLINE_VISIBILITY ~_event_cancel_base () {}
 
   void set_cancel_notifier (ptr<_event<> > e) { _cancel_notifier = e; }
   void cancel ();

--- a/libtame/tame_rendezvous.h
+++ b/libtame/tame_rendezvous.h
@@ -400,7 +400,7 @@ private:
 #endif
   }
 
-  inline void pth_init ()
+  SFS_INLINE_VISIBILITY inline void pth_init ()
   {
 #ifdef HAVE_TAME_PTH
     pth_mutex_init (&_mutex);

--- a/libtame/tame_slotset.h
+++ b/libtame/tame_slotset.h
@@ -4,11 +4,15 @@
 #ifndef _LIBTAME_TAME_SLOTSET_H_
 #define _LIBTAME_TAME_SLOTSET_H_
 
+#include "sfs_attr.h"
+
 template <typename T1=void, typename T2=void, typename T3=void, 
 	  typename T4=void>
 struct _tame_slot_set {
-  _tame_slot_set(T1 *p1_, T2 *p2_, T3 *p3_, T4 *p4_) 
+  SFS_INLINE_VISIBILITY _tame_slot_set(T1 *p1_, T2 *p2_, T3 *p3_, T4 *p4_) 
     : p1(p1_), p2(p2_), p3(p3_), p4(p4_) { }
+
+  SFS_INLINE_VISIBILITY
   void assign(const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4) {
     *p1 = v1; *p2 = v2; *p3 = v3; *p4 = v4;
   }
@@ -20,38 +24,45 @@ struct _tame_slot_set {
 
 template <typename T1, typename T2, typename T3>
 struct _tame_slot_set<T1, T2, T3, void> {
-    _tame_slot_set(T1 *p1_, T2 *p2_, T3 *p3_) : p1(p1_), p2(p2_), p3(p3_) { }
-    void assign(const T1 &v1, const T2 &v2, const T3 &v3) {
-	*p1 = v1; *p2 = v2; *p3 = v3;
-    }
-    T1 *p1;
-    T2 *p2;
-    T3 *p3;
+  SFS_INLINE_VISIBILITY
+  _tame_slot_set(T1 *p1_, T2 *p2_, T3 *p3_) : p1(p1_), p2(p2_), p3(p3_) { }
+
+  SFS_INLINE_VISIBILITY
+  void assign(const T1 &v1, const T2 &v2, const T3 &v3) {
+    *p1 = v1; *p2 = v2; *p3 = v3;
+  }
+  T1 *p1;
+  T2 *p2;
+  T3 *p3;
 };
 
 template <typename T1, typename T2>
 struct _tame_slot_set<T1, T2, void, void> {
-    _tame_slot_set(T1 *p1_, T2 *p2_) : p1(p1_), p2(p2_) { }
-    void assign(const T1 &v1, const T2 &v2) {
-	*p1 = v1; *p2 = v2;
-    }
-    T1 *p1;
-    T2 *p2;
+  SFS_INLINE_VISIBILITY _tame_slot_set(T1 *p1_, T2 *p2_) : p1(p1_), p2(p2_) { }
+
+  SFS_INLINE_VISIBILITY
+  void assign(const T1 &v1, const T2 &v2) {
+    *p1 = v1; *p2 = v2;
+  }
+  T1 *p1;
+  T2 *p2;
 };
 
 template <typename T1>
 struct _tame_slot_set<T1, void, void, void> {
-    _tame_slot_set(T1 *p1_) : p1(p1_) { }
-    void assign(const T1 &v1) {
-	*p1 = v1;
-    }
-    T1 *p1;
+  SFS_INLINE_VISIBILITY _tame_slot_set(T1 *p1_) : p1(p1_) { }
+
+  SFS_INLINE_VISIBILITY void assign(const T1 &v1) {
+    *p1 = v1;
+  }
+
+  T1 *p1;
 };
 
 template <>
 struct _tame_slot_set<void, void, void, void> {
-    _tame_slot_set() { }
-    void assign() { }
+  SFS_INLINE_VISIBILITY _tame_slot_set() { }
+  SFS_INLINE_VISIBILITY void assign() { }
 };
 
 

--- a/tame/processor.C
+++ b/tame/processor.C
@@ -538,7 +538,8 @@ tame_fn_t::output_set_method_pointer (my_strbuf_t &b)
     b << " const";
   b << ";\n";
 
-  b << "  void set_method_pointer (method_type_t m) { _method = m; }\n\n";
+  b << "  void set_method_pointer (method_type_t m) "
+    "{ _method = m; }\n\n";
     
 }
 
@@ -571,7 +572,7 @@ tame_fn_t::output_closure (outputter_t *o)
     slfargs = _args;
   }
 
-  b << "class " << _closure.type ().base_type () 
+  b << "class SFS_HIDDEN " << _closure.type ().base_type () 
     << " : public closure_t "
     << "{\n"
     << "public:\n"
@@ -610,7 +611,7 @@ tame_fn_t::output_closure (outputter_t *o)
 
   // output the argument capture structure
   b << "\n"
-    << "  struct args_t {\n"
+    << "struct SFS_HIDDEN args_t {\n"
     << "    args_t (" ;
   if (_args && _args->size ()) 
     _args->paramlist (b, DECLARATIONS);
@@ -630,7 +631,7 @@ tame_fn_t::output_closure (outputter_t *o)
   b << "  args_t _args;\n" ;
 
   // output the stack structure
-  b << "  struct stack_t {\n"
+  b << "struct SFS_HIDDEN stack_t {\n"
     << "    stack_t (";
   if (slfargs) slfargs->paramlist (b, DECLARATIONS);
 


### PR DESCRIPTION
This reduces the number of binary symbols that are exported by marking a lot of templated functions as inline and hidden. Applying this patch causes the number of symbols exported by libmodule to be divided by 4 and the link time to be divided by more than 2; programs should also run a tiny bit faster. No changes are required to oksrc or okws.