### PR TITLE
vec + refcnt: implement some STL typedefs

### DIFF
--- a/async/refcnt.h
+++ b/async/refcnt.h
@@ -504,6 +504,7 @@ class ptr : public refpriv, public refops <T> {
 
 public:
   typedef T type;
+  typedef T element_type;
   typedef struct ref<T> ref;
 
   explicit ptr (__bss_init) {}

--- a/async/vec.h
+++ b/async/vec.h
@@ -152,6 +152,10 @@ do {								\
 #endif /* !CHECK_BOUNDS */
 
 public:
+  typedef T value_type;
+  typedef elm_t *iterator;
+  typedef const elm_t *const_iterator;
+
   vec () { init (); }
   vec (const vec &v) { init (); append (v); }
 


### PR DESCRIPTION
Allows greater useability as an STL-style container. In particular, this
addition allows us to use Google Mock's "ElementsAre" matcher family on
arguments of type vec, rpc_vec, etc.