### PR TITLE
-Werror option will cause some error

### DIFF
--- a/acsfs.m4
+++ b/acsfs.m4
@@ -1504,15 +1504,15 @@ test "${CXXDEBUG+set}" || CXXDEBUG="$CXXFLAGS"
 export CXXDEBUG
 case $host_os in
     openbsd*)
-	sfs_gnu_WFLAGS="-Wall -Wsign-compare -Wchar-subscripts -Werror"
+	sfs_gnu_WFLAGS="-Wall -Wsign-compare -Wchar-subscripts"
 	sfs_gnu_CXXWFLAGS="$sfs_gnu_WFLAGS"
 	;;
     linux*)
-	sfs_gnu_WFLAGS="-Wall -Werror"
+	sfs_gnu_WFLAGS="-Wall"
 	sfs_gnu_CXXWFLAGS="$sfs_gnu_WFLAGS -Wno-mismatched-tags -Wno-overloaded-virtual -Wno-unused-private-field"
 	;;
     freebsd*)
-	sfs_gnu_WFLAGS="-Wall -Werror"
+	sfs_gnu_WFLAGS="-Wall"
 	sfs_gnu_CXXWFLAGS="$sfs_gnu_WFLAGS"
 	;;
     *)

--- a/arpc/arpc.h
+++ b/arpc/arpc.h
@@ -70,8 +70,10 @@ struct cxx_auth_ops {
 class auto_auth {
   AUTH *auth;
 
+public:
   auto_auth (const auto_auth &);
   auto_auth &operator= (const auto_auth &);
+private:
   void destroy () { if (auth) AUTH_DESTROY (auth); }
 public:
   auto_auth (AUTH *a = NULL) : auth (a) {}


### PR DESCRIPTION
I configure with '--with-sfsmisc' option, and compile with newest g++. Then there are some errors caused by warning, and some errors such as '**** is private'. So, I removed -Werror option and change some members from private to public.