### PR TITLE
Fixes to make it compile under macOS (Xcode 8)

### DIFF
--- a/arpc/arpc.h
+++ b/arpc/arpc.h
@@ -70,10 +70,10 @@ struct cxx_auth_ops {
 class auto_auth {
   AUTH *auth;
 
-  auto_auth (const auto_auth &);
-  auto_auth &operator= (const auto_auth &);
   void destroy () { if (auth) AUTH_DESTROY (auth); }
 public:
+  auto_auth (const auto_auth &);
+  auto_auth &operator= (const auto_auth &);
   auto_auth (AUTH *a = NULL) : auth (a) {}
   auto_auth (auto_auth &a) : auth (a.auth) { a.auth = NULL; }
   ~auto_auth () { destroy (); }

--- a/arpc/asrv.C
+++ b/arpc/asrv.C
@@ -445,7 +445,7 @@ xdr_virtual_version (XDR *x)
   u_int32_t rpcvers = RPC_MSG_VERSION;
   if (v_XDR_dispatch) {
     u_int32_t pos = xdr_getpos (x);
-    int32_t *buf = XDR_INLINE (x, 3*4);
+    int32_t *buf = (int32_t*)XDR_INLINE (x, 3*4);
     if (buf) {
       rpcvers = htonl (buf[2]);
       if (rpcvers != RPC_MSG_VERSION) {

--- a/async/socket.C
+++ b/async/socket.C
@@ -36,6 +36,10 @@ int bindresvport (int, struct sockaddr_in *);
 #include <netinet/ip.h>
 }
 
+#ifdef __APPLE__
+#define s6_addr32 __u6_addr.__u6_addr32
+#endif
+
 #ifdef SFS_ALLOW_LARGE_BUFFER
 enum { maxsobufsize = 0x11000 }; /* 64K + header */
 #else /* !SFS_ALLOW_LARGE_BUFFER */

--- a/async/str.h
+++ b/async/str.h
@@ -148,7 +148,6 @@ public:
   size_t len () const { return b->len; }
   const char *cstr () const { return b ? b->dat () : NULL; }
   operator const char *() const
-  DEPRECATED("use cstr instead.")
   {
     return cstr ();
   }


### PR DESCRIPTION
I needed to make this small changes to make it compile under Xcode8 toolchain with sfsmisc enabled. 

 I do not exactly know why I needed to move the methods in arpc.h from private to public. They are clearly accessed from outside of the class. Should not compile under any compiler, right?

Needed to remove the deprecated annotation since this is an error now. A better solution is clearly to actually replace the calls to this method.